### PR TITLE
[Claude] Experiment: route profile visualizations — 2D perpendicular bars + 3D extruded columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,8 +344,8 @@
           <div class="profile-bars-control-row">
             <label for="profile-bars-side">Seite</label>
             <select id="profile-bars-side" class="heightgraph-select">
-              <option value="right">Rechts der Fahrtrichtung</option>
-              <option value="left">Links der Fahrtrichtung</option>
+              <option value="east">Osten (rechts)</option>
+              <option value="west">Westen (links)</option>
             </select>
           </div>
           <div class="profile-bars-control-row">

--- a/index.html
+++ b/index.html
@@ -320,7 +320,42 @@
         </div>
         <div id="heightgraph-stats" class="heightgraph-stats"></div>
       </div>
-      
+
+      <div id="profile-bars-container" class="profile-bars-container">
+        <div class="profile-bars-header">
+          <div class="profile-bars-title">
+            <span>Routenprofil-Balken</span>
+            <span class="info-icon-small" title="Zeichnet pro Streckenabschnitt einen Balken quer zur Route. Länge und Farbe codieren einen numerischen Wert (z. B. Höhe, Steigung). Die Route bildet die (gekrümmte) X-Achse.">ⓘ</span>
+          </div>
+          <label class="switch-toggle">
+            <input type="checkbox" id="profile-bars-toggle" />
+            <span class="switch-slider"></span>
+          </label>
+        </div>
+        <div id="profile-bars-controls" class="profile-bars-controls" style="display: none;">
+          <div class="profile-bars-control-row">
+            <label for="profile-bars-value">Wert</label>
+            <select id="profile-bars-value" class="heightgraph-select"></select>
+          </div>
+          <div class="profile-bars-control-row">
+            <label for="profile-bars-scheme">Farbskala</label>
+            <select id="profile-bars-scheme" class="heightgraph-select"></select>
+          </div>
+          <div class="profile-bars-control-row">
+            <label for="profile-bars-side">Seite</label>
+            <select id="profile-bars-side" class="heightgraph-select">
+              <option value="right">Rechts der Fahrtrichtung</option>
+              <option value="left">Links der Fahrtrichtung</option>
+            </select>
+          </div>
+          <div class="profile-bars-control-row">
+            <label for="profile-bars-height">Höhe</label>
+            <input type="range" id="profile-bars-height" class="slider" min="0.01" max="0.15" step="0.01" value="0.05">
+          </div>
+          <div id="profile-bars-legend" class="profile-bars-legend" style="display: none;"></div>
+        </div>
+      </div>
+
       <div class="github-links">
         <img src="https://img.shields.io/badge/Status-Experimental-red" alt="Status: Experimental" class="status-badge">
         <div style="flex: 1;"></div>

--- a/index.html
+++ b/index.html
@@ -394,6 +394,13 @@
               <span class="switch-slider"></span>
             </label>
           </div>
+          <div class="profile-bars-control-row">
+            <label for="profile3d-terrain">Gelände 3D</label>
+            <label class="switch-toggle">
+              <input type="checkbox" id="profile3d-terrain" />
+              <span class="switch-slider"></span>
+            </label>
+          </div>
         </div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -356,6 +356,47 @@
         </div>
       </div>
 
+      <div id="profile3d-container" class="profile-bars-container">
+        <div class="profile-bars-header">
+          <div class="profile-bars-title">
+            <span>3D-Routenprofil</span>
+            <span class="info-icon-small" title="Zeichnet den Wert als senkrechte 3D-Säulen (native MapLibre fill-extrusion) – auf der Route selbst oder auf einer Basislinie daneben. Kippt die Karte in die 3D-Ansicht und kann Gebäude extrudieren.">ⓘ</span>
+          </div>
+          <label class="switch-toggle">
+            <input type="checkbox" id="profile3d-toggle" />
+            <span class="switch-slider"></span>
+          </label>
+        </div>
+        <div id="profile3d-controls" class="profile-bars-controls" style="display: none;">
+          <div class="profile-bars-control-row">
+            <label for="profile3d-variant">Säulen</label>
+            <select id="profile3d-variant" class="heightgraph-select">
+              <option value="route">Auf der Route</option>
+              <option value="baseline">Auf Basislinie (Route daneben)</option>
+            </select>
+          </div>
+          <div class="profile-bars-control-row">
+            <label for="profile3d-value">Wert</label>
+            <select id="profile3d-value" class="heightgraph-select"></select>
+          </div>
+          <div class="profile-bars-control-row">
+            <label for="profile3d-scheme">Farbskala</label>
+            <select id="profile3d-scheme" class="heightgraph-select"></select>
+          </div>
+          <div class="profile-bars-control-row">
+            <label for="profile3d-height">Höhe (m)</label>
+            <input type="range" id="profile3d-height" class="slider" min="50" max="800" step="10" value="250">
+          </div>
+          <div class="profile-bars-control-row">
+            <label for="profile3d-buildings">Gebäude 3D</label>
+            <label class="switch-toggle">
+              <input type="checkbox" id="profile3d-buildings" checked />
+              <span class="switch-slider"></span>
+            </label>
+          </div>
+        </div>
+      </div>
+
       <div class="github-links">
         <img src="https://img.shields.io/badge/Status-Experimental-red" alt="Status: Experimental" class="status-badge">
         <div style="flex: 1;"></div>

--- a/js/routing/heightgraph/heightgraphInteractivity.js
+++ b/js/routing/heightgraph/heightgraphInteractivity.js
@@ -4,11 +4,31 @@ import { routeState } from '../routeState.js';
 import { HEIGHTGRAPH_CONFIG } from './heightgraphConfig.js';
 import { calculateCumulativeDistances } from './heightgraphUtils.js';
 import { getBicycleInfraDescription } from '../colorSchemes.js';
+import { setCursorIndex, onCursorChange, getCursorIndex } from '../routeCursor.js';
 
 // Store event handlers to prevent duplicate listeners
 let heightgraphMouseMoveHandler = null;
 let heightgraphMouseLeaveHandler = null;
 let routeHighlightMarker = null;
+
+// Latest drawing context for the indicator line, refreshed on every setup, so a
+// cursor change driven by *another* view (the barchart) can redraw the line here.
+let hgIndicatorState = null;
+let cursorSubscribed = false;
+
+// Draw (or clear) the height-profile indicator line for a shared-cursor index.
+function drawIndicatorForIndex(index) {
+  const s = hgIndicatorState;
+  if (!s || !s.indicatorCanvas) return;
+  if (index == null || !s.cumulativeDistances || !s.cumulativeDistances.length || !s.totalDistance) {
+    clearIndicatorLine(s.indicatorCanvas, s.canvasWidth, s.canvasHeight);
+    return;
+  }
+  const i = Math.max(0, Math.min(s.cumulativeDistances.length - 1, index));
+  const ratio = Math.max(0, Math.min(1, s.cumulativeDistances[i] / s.totalDistance));
+  const x = s.padding.left + ratio * s.graphWidth;
+  drawIndicatorLine(s.indicatorCanvas, x, s.padding, s.graphHeight, s.canvasWidth, s.canvasHeight);
+}
 
 /**
  * Draw indicator line on indicator canvas
@@ -113,6 +133,23 @@ export function setupHeightgraphInteractivity(canvas, elevations, totalDistance,
     actualTotalDistance = computedCumulativeDistances[computedCumulativeDistances.length - 1];
   }
   
+  // Publish the current drawing context so the shared cursor can redraw the
+  // indicator line even when the move came from the barchart, and subscribe once.
+  hgIndicatorState = {
+    indicatorCanvas,
+    padding,
+    graphWidth: storedGraphWidth,
+    graphHeight: storedGraphHeight,
+    canvasWidth: storedCanvasWidth,
+    canvasHeight: storedCanvasHeight,
+    cumulativeDistances: computedCumulativeDistances,
+    totalDistance: actualTotalDistance,
+  };
+  if (!cursorSubscribed) {
+    onCursorChange(drawIndicatorForIndex);
+    cursorSubscribed = true;
+  }
+
   // Remove existing event listeners
   if (heightgraphMouseMoveHandler) {
     canvas.removeEventListener('mousemove', heightgraphMouseMoveHandler);
@@ -160,21 +197,11 @@ export function setupHeightgraphInteractivity(canvas, elevations, totalDistance,
     const topBoundary = padding.top;
     const bottomBoundary = padding.top + storedGraphHeight;
     
-    if (scaledX < leftBoundary || scaledX > rightBoundary || 
+    if (scaledX < leftBoundary || scaledX > rightBoundary ||
         scaledY < topBoundary || scaledY > bottomBoundary) {
-      // Mouse outside graph area
+      // Mouse outside the plot area: hide the tooltip but keep the shared cursor
+      // where it is (it is persistent, so the handle/point stay put).
       tooltip.style.display = 'none';
-      if (routeHighlightMarker) {
-        routeHighlightMarker.remove();
-        routeHighlightMarker = null;
-      }
-      if (routeState.mapInstance && routeState.mapInstance.getSource('heightgraph-hover-point')) {
-        routeState.mapInstance.getSource('heightgraph-hover-point').setData({
-          type: 'FeatureCollection',
-          features: []
-        });
-      }
-      clearIndicatorLine(indicatorCanvas, storedCanvasWidth, storedCanvasHeight);
       return;
     }
     
@@ -290,48 +317,25 @@ export function setupHeightgraphInteractivity(canvas, elevations, totalDistance,
       tooltip.style.top = tooltipTop + 'px';
       tooltip.style.visibility = 'visible';
       
-      // Update route highlight
-      if (coord && routeState.mapInstance) {
-        if (routeHighlightMarker) {
-          routeHighlightMarker.remove();
-          routeHighlightMarker = null;
-        }
-        
-        if (routeState.mapInstance.getSource('heightgraph-hover-point')) {
-          routeState.mapInstance.getSource('heightgraph-hover-point').setData({
-            type: 'Feature',
-            geometry: {
-              type: 'Point',
-              coordinates: [coord[0], coord[1]]
-            },
-            properties: {}
-          });
-        }
-        
-        // Draw indicator line
-        drawIndicatorLine(indicatorCanvas, segmentMidX, padding, storedGraphHeight, storedCanvasWidth, storedCanvasHeight);
-      }
+      // Move the shared cursor. This updates the route-line point, the barchart
+      // handle and (via the subscription above) this indicator line — all in sync.
+      setCursorIndex(dataIndex);
     }
   };
   
   heightgraphMouseLeaveHandler = () => {
+    // Only hide the tooltip — the shared cursor is persistent, so the indicator
+    // line, route-line point and barchart handle stay at the last position.
     tooltip.style.display = 'none';
-    if (routeHighlightMarker) {
-      routeHighlightMarker.remove();
-      routeHighlightMarker = null;
-    }
-    if (routeState.mapInstance && routeState.mapInstance.getSource('heightgraph-hover-point')) {
-      routeState.mapInstance.getSource('heightgraph-hover-point').setData({
-        type: 'FeatureCollection',
-        features: []
-      });
-    }
-    clearIndicatorLine(indicatorCanvas, storedCanvasWidth, storedCanvasHeight);
   };
   
   // Add event listeners
   canvas.addEventListener('mousemove', heightgraphMouseMoveHandler);
   canvas.addEventListener('mouseleave', heightgraphMouseLeaveHandler);
+
+  // Restore the indicator line for the persistent cursor after a redraw
+  // (encoded-value change, resize, theme switch).
+  drawIndicatorForIndex(getCursorIndex());
 }
 
 /**
@@ -360,14 +364,11 @@ export function cleanupInteractivityHandlers() {
   if (tooltip) {
     tooltip.remove();
   }
-  
-  if (routeState.mapInstance && routeState.mapInstance.getSource('heightgraph-hover-point')) {
-    routeState.mapInstance.getSource('heightgraph-hover-point').setData({
-      type: 'FeatureCollection',
-      features: []
-    });
-  }
-  
+
+  // Note: the route-line point ('heightgraph-hover-point') is owned by the shared
+  // cursor now and is cleared via clearCursor() on route clear — not here, so it
+  // survives heightgraph redraws.
+
   if (routeHighlightMarker) {
     routeHighlightMarker.remove();
     routeHighlightMarker = null;

--- a/js/routing/routeCursor.js
+++ b/js/routing/routeCursor.js
@@ -1,0 +1,77 @@
+// Shared route cursor — a single "scrub position" along the route that every
+// view reflects: the height-profile indicator line, the red point on the route
+// line, and the draggable handle on the route-profile barchart.
+//
+// The cursor is one route-coordinate index. Any view can move it (set), and any
+// view can subscribe to render it (onCursorChange). Keeping it here — instead of
+// inside one view — is what lets the three stay in sync, and makes the behaviour
+// trivial to re-create in a React port (a piece of shared state + a context).
+
+import { routeState } from './routeState.js';
+
+const HOVER_POINT_SOURCE = 'heightgraph-hover-point';
+
+let cursorIndex = null;
+const listeners = new Set();
+
+/** @returns {number|null} current route-coordinate index of the cursor */
+export function getCursorIndex() {
+  return cursorIndex;
+}
+
+/**
+ * Subscribe to cursor changes. The callback receives the new index (or null).
+ * @param {(index: number|null) => void} fn
+ * @returns {() => void} unsubscribe
+ */
+export function onCursorChange(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+/**
+ * Move the cursor. Pass null to hide it. The index is clamped to the route.
+ * No-ops when the value is unchanged so views don't redraw needlessly.
+ * @param {number|null} index
+ */
+export function setCursorIndex(index) {
+  const coords = routeState.currentRouteData && routeState.currentRouteData.coordinates;
+  let next = null;
+  if (index != null && coords && coords.length > 0) {
+    next = Math.max(0, Math.min(coords.length - 1, Math.round(index)));
+  }
+  if (next === cursorIndex) return;
+  cursorIndex = next;
+  updateMapPoint();
+  listeners.forEach((fn) => {
+    try {
+      fn(cursorIndex);
+    } catch (e) {
+      console.warn('routeCursor listener failed:', e);
+    }
+  });
+}
+
+/** Hide the cursor (e.g. when the route is cleared). */
+export function clearCursor() {
+  setCursorIndex(null);
+}
+
+// The red point on the route line is owned by the cursor so it stays correct no
+// matter which view moved it.
+function updateMapPoint() {
+  const map = routeState.mapInstance;
+  const src = map && map.getSource(HOVER_POINT_SOURCE);
+  if (!src) return;
+  const coords = routeState.currentRouteData && routeState.currentRouteData.coordinates;
+  if (cursorIndex == null || !coords || !coords[cursorIndex]) {
+    src.setData({ type: 'FeatureCollection', features: [] });
+    return;
+  }
+  const c = coords[cursorIndex];
+  src.setData({
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [c[0], c[1]] },
+    properties: {},
+  });
+}

--- a/js/routing/routeProfile/profileColorScales.js
+++ b/js/routing/routeProfile/profileColorScales.js
@@ -1,0 +1,85 @@
+// Route profile color scales — pure, framework-agnostic.
+//
+// A color scale maps a normalized value t∈[0,1] to a color. This is the
+// "Man muss festlegen können, wie sich die Farben ändern" requirement: the user
+// picks a scheme, and high/low values map to colors accordingly (e.g. a danger
+// index makes high values red).
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function hexToRgb(hex) {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbToCss([r, g, b]) {
+  return `rgb(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)})`;
+}
+
+// Each scheme is an ordered list of [stop, hexColor] with stops in [0, 1].
+export const COLOR_SCHEMES = {
+  danger: {
+    label: 'Gefahr (Grün → Gelb → Rot)',
+    stops: [[0, '#22c55e'], [0.5, '#eab308'], [1, '#dc2626']],
+  },
+  bluered: {
+    label: 'Sequenziell (Blau → Rot)',
+    stops: [[0, '#3b82f6'], [0.5, '#a855f7'], [1, '#ef4444']],
+  },
+  viridis: {
+    label: 'Viridis',
+    stops: [
+      [0, '#440154'], [0.25, '#3b528b'], [0.5, '#21918c'],
+      [0.75, '#5ec962'], [1, '#fde725'],
+    ],
+  },
+  cool: {
+    label: 'Kühl (Hell → Blau)',
+    stops: [[0, '#e0f2fe'], [1, '#1d4ed8']],
+  },
+  mono: {
+    label: 'Einfarbig (Violett)',
+    stops: [[0, '#ddd6fe'], [1, '#6d28d9']],
+  },
+};
+
+/**
+ * Color for a normalized value t∈[0,1] under the given scheme.
+ * @param {string} schemeId - key of COLOR_SCHEMES
+ * @param {number} t - normalized value, clamped to [0, 1]
+ * @returns {string} CSS rgb() color
+ */
+export function colorForT(schemeId, t) {
+  const scheme = COLOR_SCHEMES[schemeId] || COLOR_SCHEMES.danger;
+  const stops = scheme.stops;
+  const x = Math.max(0, Math.min(1, Number.isFinite(t) ? t : 0));
+
+  for (let i = 1; i < stops.length; i++) {
+    if (x <= stops[i][0]) {
+      const [s0, c0] = stops[i - 1];
+      const [s1, c1] = stops[i];
+      const local = (x - s0) / (s1 - s0 || 1);
+      const a = hexToRgb(c0);
+      const b = hexToRgb(c1);
+      return rgbToCss([
+        lerp(a[0], b[0], local),
+        lerp(a[1], b[1], local),
+        lerp(a[2], b[2], local),
+      ]);
+    }
+  }
+  return rgbToCss(hexToRgb(stops[stops.length - 1][1]));
+}
+
+/**
+ * CSS `linear-gradient(...)` string for rendering a scheme in a legend.
+ * @param {string} schemeId
+ * @returns {string}
+ */
+export function cssGradient(schemeId) {
+  const scheme = COLOR_SCHEMES[schemeId] || COLOR_SCHEMES.danger;
+  const stops = scheme.stops.map(([s, c]) => `${c} ${Math.round(s * 100)}%`).join(', ');
+  return `linear-gradient(to right, ${stops})`;
+}

--- a/js/routing/routeProfile/profileGeometry.js
+++ b/js/routing/routeProfile/profileGeometry.js
@@ -52,40 +52,49 @@ function resample(xy, cum, step) {
   return out;
 }
 
-// Moving-average smoothing with a symmetric window of radius w samples.
-function smooth(points, w) {
-  if (w < 1) return points.slice();
+// Endpoint-preserving Laplacian smoothing: each interior point relaxes toward the
+// midpoint of its neighbours. Unlike a wide moving average it does NOT collapse the
+// curve to its centroid — it converges toward the straight chord between the fixed
+// endpoints, which is exactly the "more straight than curvy" baseline we want.
+function laplacianSmooth(points, iters, lambda = 0.5) {
   const n = points.length;
-  const out = new Array(n);
-  for (let i = 0; i < n; i++) {
-    let sx = 0;
-    let sy = 0;
-    let c = 0;
-    for (let j = Math.max(0, i - w); j <= Math.min(n - 1, i + w); j++) {
-      sx += points[j][0];
-      sy += points[j][1];
-      c++;
+  let cur = points.map((p) => [p[0], p[1]]);
+  if (n < 3 || iters < 1) return cur;
+  let next = points.map((p) => [p[0], p[1]]);
+  for (let it = 0; it < iters; it++) {
+    for (let i = 1; i < n - 1; i++) {
+      next[i][0] = cur[i][0] + lambda * ((cur[i - 1][0] + cur[i + 1][0]) / 2 - cur[i][0]);
+      next[i][1] = cur[i][1] + lambda * ((cur[i - 1][1] + cur[i + 1][1]) / 2 - cur[i][1]);
     }
-    out[i] = [sx / c, sy / c];
+    const tmp = cur;
+    cur = next;
+    next = tmp;
   }
-  return out;
+  return cur;
 }
 
-// Moving-average smoothing for a scalar array (window radius w).
-function smooth1d(arr, w) {
-  if (w < 1) return arr.slice();
-  const n = arr.length;
-  const out = new Array(n);
-  for (let i = 0; i < n; i++) {
-    let s = 0;
-    let c = 0;
-    for (let j = Math.max(0, i - w); j <= Math.min(n - 1, i + w); j++) {
-      s += arr[j];
-      c++;
+// Does an (open) polyline cross itself? O(n^2) over non-adjacent segment pairs.
+function ccw(a, b, c) {
+  return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]);
+}
+function segmentsIntersect(p1, p2, p3, p4) {
+  const d1 = ccw(p3, p4, p1);
+  const d2 = ccw(p3, p4, p2);
+  const d3 = ccw(p1, p2, p3);
+  const d4 = ccw(p1, p2, p4);
+  return (
+    ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+    ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))
+  );
+}
+function polylineSelfIntersects(P) {
+  const n = P.length;
+  for (let i = 0; i < n - 1; i++) {
+    for (let j = i + 2; j < n - 1; j++) {
+      if (segmentsIntersect(P[i], P[i + 1], P[j], P[j + 1])) return true;
     }
-    out[i] = s / c;
   }
-  return out;
+  return false;
 }
 
 // Unit tangents via central difference.
@@ -170,37 +179,34 @@ export function buildProfileBars(coordinates, segmentValues, opts = {}) {
   const smoothMeters = opts.smoothingMeters != null ? opts.smoothingMeters : barWidth * 3;
   const offset = opts.baseOffsetMeters != null ? opts.baseOffsetMeters : maxLen * 0.08;
 
-  // 1. Smooth, offset baseline (the abstracted "curved X-axis").
+  // 1. Clean, mostly-straight baseline (the abstracted "curved X-axis").
+  // Smooth the centerline and offset it; then keep increasing the smoothing window
+  // until even the bar tips form a *simple* (non-self-intersecting) line. Offset
+  // curves fold on the inside of bends sharper than the offset distance, so
+  // straightening those bends until the fold disappears guarantees a clean line
+  // with no overlapping bars — leaning straight rather than curvy, as desired.
   const R = resample(xy, cumOrig, step); // R[k] at arc-length k*step
   if (R.length < 3) return emptyResult();
   const K = R.length;
-  const w = Math.max(0, Math.round(smoothMeters / step));
-  const S = smooth(R, w);
-  const T = tangents(S);
-  const N = T.map(([dx, dy]) => (side === 'left' ? [-dy, dx] : [dy, -dx]));
-
-  // The baseline = smoothed centerline pushed outward by `offset` PLUS the route's
-  // own outward deviation from that centerline. Without the deviation term a very
-  // smooth baseline would be crossed by the wiggly route at its peaks; with it the
-  // baseline stays a clean ~`offset` clear of the route everywhere. The deviation
-  // is dilated over the smoothing window (so peaks are cleared) then re-smoothed.
-  const dev = new Array(K);
-  for (let k = 0; k < K; k++) {
-    dev[k] = Math.max(0, (R[k][0] - S[k][0]) * N[k][0] + (R[k][1] - S[k][1]) * N[k][1]);
+  const reach = offset + maxLen; // farthest a bar tip can sit from the centerline
+  // Laplacian iterations needed to smooth over `smoothMeters` (~ (scale/spacing)^2).
+  const baseIters = Math.max(2, Math.round((smoothMeters / step) ** 2));
+  const maxIters = Math.max(baseIters, 6000);
+  let S;
+  let T;
+  let N;
+  let iters = baseIters;
+  for (let attempt = 0; attempt < 14; attempt++) {
+    S = laplacianSmooth(R, iters);
+    T = tangents(S);
+    N = T.map(([dx, dy]) => (side === 'left' ? [-dy, dx] : [dy, -dx]));
+    const outer = S.map((p, k) => [p[0] + N[k][0] * reach, p[1] + N[k][1] * reach]);
+    if (!polylineSelfIntersects(outer) || iters >= maxIters) break;
+    iters = Math.min(maxIters, iters * 2);
   }
-  const devClear = new Array(K);
-  for (let k = 0; k < K; k++) {
-    let m = 0;
-    const lo = Math.max(0, k - w);
-    const hi = Math.min(K - 1, k + w);
-    for (let j = lo; j <= hi; j++) if (dev[j] > m) m = dev[j];
-    devClear[k] = m;
-  }
-  const devSmooth = smooth1d(devClear, Math.max(1, Math.round(w / 2)));
-  const B = S.map((p, k) => {
-    const d = offset + devSmooth[k];
-    return [p[0] + N[k][0] * d, p[1] + N[k][1] * d];
-  });
+  const B = S.map((p, k) => [p[0] + N[k][0] * offset, p[1] + N[k][1] * offset]);
+  const baselineCum = cumulative(B);
+  const D = baselineCum[K - 1] || 1; // baseline length
 
   // 2. Value at each resample point (piecewise-constant from the route segments).
   const gv = new Array(K).fill(null);
@@ -221,15 +227,37 @@ export function buildProfileBars(coordinates, segmentValues, opts = {}) {
   };
   const nearest = (arr, idx) => arr[Math.max(0, Math.min(arr.length - 1, Math.round(idx)))];
 
-  // 3. Resample one value per uniform bar (mean over the bar's arc-length window).
-  const numBars = Math.max(1, Math.floor(L / barWidth));
+  // Fractional resample index at a given baseline arc-length (so we can place
+  // things by distance ALONG the baseline rather than by route arc-length).
+  const fracIndexAtArc = (s) => {
+    if (s <= 0) return 0;
+    if (s >= D) return K - 1;
+    let lo = 0;
+    let hi = K - 1;
+    while (lo < hi) {
+      const m = (lo + hi) >> 1;
+      if (baselineCum[m] < s) lo = m + 1;
+      else hi = m;
+    }
+    const i0 = Math.max(0, lo - 1);
+    const segLen = baselineCum[lo] - baselineCum[i0] || 1;
+    return i0 + (s - baselineCum[i0]) / segLen;
+  };
+
+  // 3. Bars are spaced evenly along the BASELINE (not the route), so a straighter
+  // baseline never crowds or overlaps them. Each bar averages the route value over
+  // the route span that maps to its slice of the baseline.
+  const numBars = Math.max(1, Math.floor(D / barWidth));
+  const barW = D / numBars;
+  const fracMid = new Array(numBars);
   const raw = new Array(numBars).fill(null);
   for (let j = 0; j < numBars; j++) {
-    const i0 = Math.round((j * barWidth) / step);
-    const i1 = Math.round(((j + 1) * barWidth) / step);
+    const kLo = Math.round(fracIndexAtArc(j * barW));
+    const kHi = Math.round(fracIndexAtArc((j + 1) * barW));
+    fracMid[j] = fracIndexAtArc((j + 0.5) * barW);
     let sum = 0;
     let c = 0;
-    for (let k = i0; k <= i1 && k < K; k++) {
+    for (let k = kLo; k <= kHi && k < K; k++) {
       if (gv[k] != null) {
         sum += gv[k];
         c++;
@@ -257,11 +285,11 @@ export function buildProfileBars(coordinates, segmentValues, opts = {}) {
     const len = t * maxLen;
     if (len <= 0) continue;
 
-    const centerIdx = ((j + 0.5) * barWidth) / step;
-    const P = at(B, centerIdx);
-    const tan = nearest(T, centerIdx);
-    const nor = nearest(N, centerIdx);
-    const hw = (barWidth * gap) / 2;
+    const idx = fracMid[j];
+    const P = at(B, idx);
+    const tan = nearest(T, idx);
+    const nor = nearest(N, idx);
+    const hw = (barW * gap) / 2;
 
     const b1 = [P[0] - tan[0] * hw, P[1] - tan[1] * hw];
     const b2 = [P[0] + tan[0] * hw, P[1] + tan[1] * hw];
@@ -269,9 +297,9 @@ export function buildProfileBars(coordinates, segmentValues, opts = {}) {
     const t1 = [b1[0] + nor[0] * len, b1[1] + nor[1] * len];
     const ring = [b1, b2, t2, t1, b1].map(proj.toLngLat);
 
-    // Route-coordinate index at this bar's center — lets the shared cursor map a
-    // hovered bar back to a position on the route line and height profile.
-    const routeIndex = nearestIndexByArcLength(cumOrig, (j + 0.5) * barWidth);
+    // Route-coordinate index at this bar's center (resample index idx -> route
+    // arc-length idx*step) — lets the shared cursor map a hovered bar to the route.
+    const routeIndex = nearestIndexByArcLength(cumOrig, idx * step);
 
     features.push({
       type: 'Feature',

--- a/js/routing/routeProfile/profileGeometry.js
+++ b/js/routing/routeProfile/profileGeometry.js
@@ -1,0 +1,290 @@
+// Route profile geometry — pure, framework-agnostic.
+//
+// Builds a "perpendicular histogram" beside a route. The wiggly route is NOT
+// used directly as the bar baseline — instead a smoothed, offset version of it
+// is derived (the "vereinfachte Basislinie als gekrümmte X-Achse" from the
+// brief). Bars are resampled to a uniform width and stand perpendicular to that
+// smooth baseline, so the chart stays clean even where the route kinks.
+//
+// No MapLibre / DOM dependency, so this can be reused unchanged in a React port.
+
+const M_PER_DEG_LAT = 111320;
+
+// Local equirectangular projection to meters around the route. Distortion is
+// negligible for a regional route and lets us do all vector math in a flat,
+// metric frame, converting back to lng/lat only at the end.
+function makeProjector(coordinates) {
+  let latSum = 0;
+  for (const c of coordinates) latSum += c[1];
+  const lat0 = latSum / coordinates.length;
+  const lng0 = coordinates[0][0];
+  const mLng = 111320 * Math.cos((lat0 * Math.PI) / 180) || 1;
+  return {
+    toXY: ([lng, lat]) => [(lng - lng0) * mLng, (lat - lat0) * M_PER_DEG_LAT],
+    toLngLat: ([x, y]) => [lng0 + x / mLng, lat0 + y / M_PER_DEG_LAT],
+  };
+}
+
+const dist2 = (a, b) => Math.hypot(b[0] - a[0], b[1] - a[1]);
+
+// Cumulative arc-length along an xy polyline.
+function cumulative(xy) {
+  const cum = [0];
+  for (let i = 1; i < xy.length; i++) cum.push(cum[i - 1] + dist2(xy[i - 1], xy[i]));
+  return cum;
+}
+
+// Resample an xy polyline to points spaced `step` meters apart. out[k] sits at
+// arc-length k * step, so the index is a direct arc-length parametrization.
+function resample(xy, cum, step) {
+  const total = cum[cum.length - 1];
+  const out = [];
+  let seg = 0;
+  for (let s = 0; s <= total; s += step) {
+    while (seg < xy.length - 2 && cum[seg + 1] < s) seg++;
+    const segLen = cum[seg + 1] - cum[seg] || 1;
+    const f = (s - cum[seg]) / segLen;
+    out.push([
+      xy[seg][0] + f * (xy[seg + 1][0] - xy[seg][0]),
+      xy[seg][1] + f * (xy[seg + 1][1] - xy[seg][1]),
+    ]);
+  }
+  return out;
+}
+
+// Moving-average smoothing with a symmetric window of radius w samples.
+function smooth(points, w) {
+  if (w < 1) return points.slice();
+  const n = points.length;
+  const out = new Array(n);
+  for (let i = 0; i < n; i++) {
+    let sx = 0;
+    let sy = 0;
+    let c = 0;
+    for (let j = Math.max(0, i - w); j <= Math.min(n - 1, i + w); j++) {
+      sx += points[j][0];
+      sy += points[j][1];
+      c++;
+    }
+    out[i] = [sx / c, sy / c];
+  }
+  return out;
+}
+
+// Moving-average smoothing for a scalar array (window radius w).
+function smooth1d(arr, w) {
+  if (w < 1) return arr.slice();
+  const n = arr.length;
+  const out = new Array(n);
+  for (let i = 0; i < n; i++) {
+    let s = 0;
+    let c = 0;
+    for (let j = Math.max(0, i - w); j <= Math.min(n - 1, i + w); j++) {
+      s += arr[j];
+      c++;
+    }
+    out[i] = s / c;
+  }
+  return out;
+}
+
+// Unit tangents via central difference.
+function tangents(points) {
+  const n = points.length;
+  const T = new Array(n);
+  for (let i = 0; i < n; i++) {
+    const a = points[Math.max(0, i - 1)];
+    const b = points[Math.min(n - 1, i + 1)];
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    const len = Math.hypot(dx, dy) || 1;
+    T[i] = [dx / len, dy / len];
+  }
+  return T;
+}
+
+const lineFeature = (xyPts, proj) => ({
+  type: 'Feature',
+  geometry: { type: 'LineString', coordinates: xyPts.map(proj.toLngLat) },
+  properties: {},
+});
+
+function emptyResult() {
+  return {
+    bars: { type: 'FeatureCollection', features: [] },
+    baseline: { type: 'Feature', geometry: { type: 'LineString', coordinates: [] }, properties: {} },
+    domain: { min: 0, max: 1 },
+    step: 1,
+    routeCum: [],
+  };
+}
+
+// Index of the route coordinate whose cumulative arc-length is closest to `s`
+// (cum is sorted ascending). Binary search.
+function nearestIndexByArcLength(cum, s) {
+  let lo = 0;
+  let hi = cum.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (cum[mid] < s) lo = mid + 1;
+    else hi = mid;
+  }
+  if (lo > 0 && Math.abs(cum[lo - 1] - s) <= Math.abs(cum[lo] - s)) return lo - 1;
+  return lo;
+}
+
+/**
+ * Build the smooth-baseline histogram for a route.
+ *
+ * @param {Array<[number, number]>} coordinates - route as [lng, lat] points
+ * @param {Array<number|null>} segmentValues - one value per route segment
+ *        (length coordinates.length - 1)
+ * @param {Object} [opts]
+ * @param {'left'|'right'} [opts.side='right'] - side the baseline + bars sit on
+ * @param {number} [opts.maxBarLengthMeters=300] - bar length at t = 1
+ * @param {number} [opts.barWidthMeters] - width of each resampled bar (default L/90)
+ * @param {number} [opts.smoothingMeters] - baseline smoothing window (default 3 × bar width)
+ * @param {number} [opts.baseOffsetMeters] - gap between route and baseline (default 8% of max bar)
+ * @param {number} [opts.sampleStepMeters] - baseline resampling resolution (default bar width / 4)
+ * @param {number} [opts.minValue] / [opts.maxValue] - value domain (default: resampled data range)
+ * @param {(t: number, value: number) => string} [opts.colorForT] - color per normalized value
+ * @returns {{bars: Object, baseline: Object, domain: {min:number, max:number}}}
+ *          GeoJSON bars (Polygons), the baseline (LineString), and the value domain used.
+ */
+export function buildProfileBars(coordinates, segmentValues, opts = {}) {
+  if (!coordinates || coordinates.length < 3 || !segmentValues || segmentValues.length < 2) {
+    return emptyResult();
+  }
+
+  const side = opts.side === 'left' ? 'left' : 'right';
+  const maxLen = opts.maxBarLengthMeters > 0 ? opts.maxBarLengthMeters : 300;
+
+  const proj = makeProjector(coordinates);
+  const xy = coordinates.map(proj.toXY);
+  const cumOrig = cumulative(xy);
+  const L = cumOrig[cumOrig.length - 1];
+  if (L < 1) return emptyResult();
+
+  const barWidth = opts.barWidthMeters > 0 ? opts.barWidthMeters : Math.max(5, L / 90);
+  const step = opts.sampleStepMeters > 0 ? opts.sampleStepMeters : Math.max(2, barWidth / 4);
+  const smoothMeters = opts.smoothingMeters != null ? opts.smoothingMeters : barWidth * 3;
+  const offset = opts.baseOffsetMeters != null ? opts.baseOffsetMeters : maxLen * 0.08;
+
+  // 1. Smooth, offset baseline (the abstracted "curved X-axis").
+  const R = resample(xy, cumOrig, step); // R[k] at arc-length k*step
+  if (R.length < 3) return emptyResult();
+  const K = R.length;
+  const w = Math.max(0, Math.round(smoothMeters / step));
+  const S = smooth(R, w);
+  const T = tangents(S);
+  const N = T.map(([dx, dy]) => (side === 'left' ? [-dy, dx] : [dy, -dx]));
+
+  // The baseline = smoothed centerline pushed outward by `offset` PLUS the route's
+  // own outward deviation from that centerline. Without the deviation term a very
+  // smooth baseline would be crossed by the wiggly route at its peaks; with it the
+  // baseline stays a clean ~`offset` clear of the route everywhere. The deviation
+  // is dilated over the smoothing window (so peaks are cleared) then re-smoothed.
+  const dev = new Array(K);
+  for (let k = 0; k < K; k++) {
+    dev[k] = Math.max(0, (R[k][0] - S[k][0]) * N[k][0] + (R[k][1] - S[k][1]) * N[k][1]);
+  }
+  const devClear = new Array(K);
+  for (let k = 0; k < K; k++) {
+    let m = 0;
+    const lo = Math.max(0, k - w);
+    const hi = Math.min(K - 1, k + w);
+    for (let j = lo; j <= hi; j++) if (dev[j] > m) m = dev[j];
+    devClear[k] = m;
+  }
+  const devSmooth = smooth1d(devClear, Math.max(1, Math.round(w / 2)));
+  const B = S.map((p, k) => {
+    const d = offset + devSmooth[k];
+    return [p[0] + N[k][0] * d, p[1] + N[k][1] * d];
+  });
+
+  // 2. Value at each resample point (piecewise-constant from the route segments).
+  const gv = new Array(K).fill(null);
+  let seg = 0;
+  for (let k = 0; k < K; k++) {
+    const s = k * step;
+    while (seg < segmentValues.length - 1 && cumOrig[seg + 1] <= s) seg++;
+    const v = segmentValues[seg];
+    gv[k] = v === null || v === undefined || !Number.isFinite(v) ? null : v;
+  }
+
+  // Interpolated baseline point at a fractional sample index; nearest tan/normal.
+  const at = (arr, idx) => {
+    const i0 = Math.max(0, Math.min(arr.length - 1, Math.floor(idx)));
+    const i1 = Math.min(arr.length - 1, i0 + 1);
+    const f = idx - i0;
+    return [arr[i0][0] + f * (arr[i1][0] - arr[i0][0]), arr[i0][1] + f * (arr[i1][1] - arr[i0][1])];
+  };
+  const nearest = (arr, idx) => arr[Math.max(0, Math.min(arr.length - 1, Math.round(idx)))];
+
+  // 3. Resample one value per uniform bar (mean over the bar's arc-length window).
+  const numBars = Math.max(1, Math.floor(L / barWidth));
+  const raw = new Array(numBars).fill(null);
+  for (let j = 0; j < numBars; j++) {
+    const i0 = Math.round((j * barWidth) / step);
+    const i1 = Math.round(((j + 1) * barWidth) / step);
+    let sum = 0;
+    let c = 0;
+    for (let k = i0; k <= i1 && k < K; k++) {
+      if (gv[k] != null) {
+        sum += gv[k];
+        c++;
+      }
+    }
+    raw[j] = c > 0 ? sum / c : null;
+  }
+
+  const validRaw = raw.filter((v) => v != null);
+  if (!validRaw.length) {
+    return { ...emptyResult(), baseline: lineFeature(B, proj), step, routeCum: cumOrig };
+  }
+  const minV = opts.minValue != null ? opts.minValue : Math.min(...validRaw);
+  const maxV = opts.maxValue != null ? opts.maxValue : Math.max(...validRaw);
+  const range = maxV - minV || 1;
+  const colorFn = typeof opts.colorForT === 'function' ? opts.colorForT : null;
+  const gap = 0.94; // small gaps between bars for a crisp histogram
+
+  // 4. Build uniform bar rectangles standing on the smooth baseline.
+  const features = [];
+  for (let j = 0; j < numBars; j++) {
+    const v = raw[j];
+    if (v == null) continue;
+    const t = Math.max(0, Math.min(1, (v - minV) / range));
+    const len = t * maxLen;
+    if (len <= 0) continue;
+
+    const centerIdx = ((j + 0.5) * barWidth) / step;
+    const P = at(B, centerIdx);
+    const tan = nearest(T, centerIdx);
+    const nor = nearest(N, centerIdx);
+    const hw = (barWidth * gap) / 2;
+
+    const b1 = [P[0] - tan[0] * hw, P[1] - tan[1] * hw];
+    const b2 = [P[0] + tan[0] * hw, P[1] + tan[1] * hw];
+    const t2 = [b2[0] + nor[0] * len, b2[1] + nor[1] * len];
+    const t1 = [b1[0] + nor[0] * len, b1[1] + nor[1] * len];
+    const ring = [b1, b2, t2, t1, b1].map(proj.toLngLat);
+
+    // Route-coordinate index at this bar's center — lets the shared cursor map a
+    // hovered bar back to a position on the route line and height profile.
+    const routeIndex = nearestIndexByArcLength(cumOrig, (j + 0.5) * barWidth);
+
+    features.push({
+      type: 'Feature',
+      geometry: { type: 'Polygon', coordinates: [ring] },
+      properties: { index: j, routeIndex, value: v, t, color: colorFn ? colorFn(t, v) : '#7c3aed' },
+    });
+  }
+
+  return {
+    bars: { type: 'FeatureCollection', features },
+    baseline: lineFeature(B, proj),
+    domain: { min: minV, max: maxV },
+    step, // baseline sample spacing in meters (B[k] is at route arc-length k*step)
+    routeCum: cumOrig, // route arc-length per original coordinate
+  };
+}

--- a/js/routing/routeProfile/profileValues.js
+++ b/js/routing/routeProfile/profileValues.js
@@ -1,0 +1,95 @@
+// Route profile values — maps the app's route data to a numeric series.
+//
+// The geometry/color modules are generic; this module is the app-specific glue
+// that turns `routeState.currentRouteData` into per-coordinate numbers. Add a
+// new entry to PROFILE_VALUES to expose another metric as bars.
+//
+// `compute` returns one number (or null) per ROUTE COORDINATE. The caller
+// converts that to per-segment values via toSegmentValues().
+
+import { calculateDistance } from '../heightgraph/heightgraphUtils.js';
+
+export const PROFILE_VALUES = {
+  elevation: {
+    label: 'Höhe',
+    unit: 'm',
+    available: (d) => Array.isArray(d.elevations) && d.elevations.some((e) => e != null),
+    compute: (d) => (d.elevations || []).map((e) => (Number.isFinite(e) ? e : null)),
+  },
+
+  slope: {
+    label: 'Steigung',
+    unit: '%',
+    available: (d) =>
+      Array.isArray(d.elevations) &&
+      d.elevations.some((e) => e != null) &&
+      Array.isArray(d.coordinates) &&
+      d.coordinates.length > 1,
+    // |gradient| in percent for the segment starting at coordinate i.
+    compute: (d) => {
+      const el = d.elevations || [];
+      const co = d.coordinates || [];
+      const out = new Array(co.length).fill(null);
+      for (let i = 0; i < co.length - 1; i++) {
+        const a = el[i];
+        const b = el[i + 1];
+        if (!Number.isFinite(a) || !Number.isFinite(b)) continue;
+        const dist = calculateDistance(co[i], co[i + 1]) || 1;
+        out[i] = Math.abs(((b - a) / dist) * 100);
+      }
+      // Last coordinate inherits the previous segment so the array stays aligned.
+      out[co.length - 1] = out[co.length - 2] ?? null;
+      return out;
+    },
+  },
+
+  mapillary_missing: {
+    label: 'Mapillary fehlt',
+    unit: '',
+    available: (d) => Array.isArray(d.encodedValues?.mapillary_coverage),
+    // 1 where Mapillary coverage is missing, 0 where present — on-brand for
+    // this app: tall/red bars mark the gaps in Street View coverage.
+    compute: (d) =>
+      (d.encodedValues.mapillary_coverage || []).map((v) => {
+        if (v === null || v === undefined) return null;
+        const present = v === true || v === 'true' || v === 'True' || v === 1;
+        return present ? 0 : 1;
+      }),
+  },
+};
+
+/**
+ * Convert a per-coordinate series into a per-segment series (length n - 1).
+ * @param {Array<number|null>} perCoord
+ * @param {'start'|'avg'} [mode='start'] - 'avg' smooths continuous data like
+ *        elevation; 'start' keeps the segment's start value (good for discrete data)
+ * @returns {Array<number|null>}
+ */
+export function toSegmentValues(perCoord, mode = 'start') {
+  if (!perCoord || perCoord.length < 2) return [];
+  const out = [];
+  for (let i = 0; i < perCoord.length - 1; i++) {
+    const a = perCoord[i];
+    const b = perCoord[i + 1];
+    if (mode === 'avg' && Number.isFinite(a) && Number.isFinite(b)) {
+      out.push((a + b) / 2);
+    } else {
+      out.push(Number.isFinite(a) ? a : Number.isFinite(b) ? b : null);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve a profile metric for the current route data.
+ * @param {Object} routeData - routeState.currentRouteData
+ * @param {string} valueKey - key of PROFILE_VALUES
+ * @returns {{values: Array<number|null>, label: string, unit: string, available: boolean}}
+ */
+export function getProfileSeries(routeData, valueKey) {
+  const def = PROFILE_VALUES[valueKey] || PROFILE_VALUES.elevation;
+  if (!routeData || !def.available(routeData)) {
+    return { values: [], label: def.label, unit: def.unit, available: false };
+  }
+  return { values: def.compute(routeData), label: def.label, unit: def.unit, available: true };
+}

--- a/js/routing/routeProfile/routeProfileBars.js
+++ b/js/routing/routeProfile/routeProfileBars.js
@@ -1,0 +1,440 @@
+// Route profile bars — on-map "perpendicular histogram" along the route.
+//
+// This is the ONLY module in routeProfile/ that touches MapLibre and the DOM.
+// All geometry, color and value logic lives in the pure sibling modules, so a
+// React port only needs to re-implement this thin integration layer (add a
+// <Source>/<Layer>, wire React state to `options`, call updateRouteProfileBars).
+
+import { routeState } from '../routeState.js';
+import { buildProfileBars } from './profileGeometry.js';
+import { COLOR_SCHEMES, colorForT, cssGradient } from './profileColorScales.js';
+import { PROFILE_VALUES, getProfileSeries, toSegmentValues } from './profileValues.js';
+import { setCursorIndex, onCursorChange, getCursorIndex } from '../routeCursor.js';
+
+const SOURCE_BARS = 'route-profile-bars';
+const LAYER_BARS_FILL = 'route-profile-bars-fill';
+const LAYER_BARS_LINE = 'route-profile-bars-outline';
+const SOURCE_BASELINE = 'route-profile-baseline';
+const LAYER_BASELINE = 'route-profile-baseline-line';
+
+const IDS = {
+  toggle: 'profile-bars-toggle',
+  value: 'profile-bars-value',
+  scheme: 'profile-bars-scheme',
+  side: 'profile-bars-side',
+  height: 'profile-bars-height',
+  controls: 'profile-bars-controls',
+  legend: 'profile-bars-legend',
+};
+
+// The interactive knobs. In a React port this becomes component state.
+const options = {
+  enabled: false,
+  valueKey: 'elevation',
+  scheme: 'danger',
+  side: 'right',
+  heightFactor: 0.05, // bar length at t=1 = heightFactor * total route distance
+};
+
+// Screen-space gap between the route line and the baseline the bars sit on.
+const BASELINE_OFFSET_PX = 40;
+
+let mapRef = null;
+let hoverPopup = null;
+let controlsWired = false;
+let hoverWired = false;
+let zoomWired = false;
+let lastBuiltZoom = null;
+
+// Shared-cursor handle state.
+let handleMarker = null;
+let handleSubscribed = false;
+// Geometry needed to map a route index <-> a point on the smooth baseline.
+let cursorGeom = null; // { baselineCoords, step, routeCum }
+
+function emptyFC() {
+  return { type: 'FeatureCollection', features: [] };
+}
+
+// Convert a screen-pixel distance to meters at the current map zoom, using the
+// route's mean latitude (Web Mercator ground resolution).
+function pixelsToMeters(px, coordinates) {
+  if (!mapRef || !coordinates || !coordinates.length) return px;
+  let latSum = 0;
+  for (const c of coordinates) latSum += c[1];
+  const lat = latSum / coordinates.length;
+  const mPerPx = (156543.03392 * Math.cos((lat * Math.PI) / 180)) / Math.pow(2, mapRef.getZoom());
+  return px * mPerPx;
+}
+
+/**
+ * Idempotent setup: ensures the source + layers exist and the controls/hover are
+ * wired. Safe to call again after a basemap/style change (which is exactly why
+ * it lives inside setupRouting): it re-adds the source/layers and repopulates.
+ */
+export function setupRouteProfileBars(map) {
+  mapRef = map;
+  ensureLayers(map);
+
+  if (!controlsWired) {
+    setupControls();
+    controlsWired = true;
+  }
+  if (!hoverWired) {
+    setupHover(map);
+    hoverWired = true;
+  }
+  if (!zoomWired) {
+    // Keep the baseline gap at ~40 px by rebuilding when the zoom changes.
+    map.on('moveend', () => {
+      if (!options.enabled) return;
+      const z = map.getZoom();
+      if (lastBuiltZoom == null || Math.abs(z - lastBuiltZoom) > 0.05) {
+        updateRouteProfileBars();
+      }
+    });
+    zoomWired = true;
+  }
+
+  // Repopulate (e.g. after a style change while a route is still active).
+  updateRouteProfileBars();
+}
+
+function ensureLayers(map) {
+  if (!map.getSource(SOURCE_BARS)) {
+    map.addSource(SOURCE_BARS, { type: 'geojson', data: emptyFC() });
+  }
+  if (!map.getSource(SOURCE_BASELINE)) {
+    map.addSource(SOURCE_BASELINE, { type: 'geojson', data: emptyFC() });
+  }
+  // Keep the bars beneath the route line so the route stays readable on top.
+  const beforeId = map.getLayer('route-layer') ? 'route-layer' : undefined;
+
+  if (!map.getLayer(LAYER_BARS_FILL)) {
+    map.addLayer(
+      {
+        id: LAYER_BARS_FILL,
+        type: 'fill',
+        source: SOURCE_BARS,
+        paint: { 'fill-color': ['get', 'color'], 'fill-opacity': 0.75 },
+      },
+      beforeId
+    );
+  }
+  if (!map.getLayer(LAYER_BARS_LINE)) {
+    map.addLayer(
+      {
+        id: LAYER_BARS_LINE,
+        type: 'line',
+        source: SOURCE_BARS,
+        paint: { 'line-color': ['get', 'color'], 'line-width': 0.5, 'line-opacity': 0.9 },
+      },
+      beforeId
+    );
+  }
+  // The abstracted baseline ("curved X-axis") the bars stand on.
+  if (!map.getLayer(LAYER_BASELINE)) {
+    map.addLayer(
+      {
+        id: LAYER_BASELINE,
+        type: 'line',
+        source: SOURCE_BASELINE,
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-color': '#64748b', 'line-width': 1.2, 'line-opacity': 0.85 },
+      },
+      beforeId
+    );
+  }
+}
+
+function setupControls() {
+  populateSelectors();
+
+  const toggle = document.getElementById(IDS.toggle);
+  const controls = document.getElementById(IDS.controls);
+  if (toggle) {
+    toggle.checked = options.enabled;
+    if (controls) controls.style.display = options.enabled ? 'block' : 'none';
+    toggle.addEventListener('change', (e) => {
+      options.enabled = e.target.checked;
+      if (controls) controls.style.display = options.enabled ? 'block' : 'none';
+      updateRouteProfileBars();
+    });
+  }
+
+  bindSelect(IDS.value, 'valueKey');
+  bindSelect(IDS.scheme, 'scheme');
+  bindSelect(IDS.side, 'side');
+
+  const height = document.getElementById(IDS.height);
+  if (height) {
+    height.value = String(options.heightFactor);
+    height.addEventListener('input', (e) => {
+      options.heightFactor = parseFloat(e.target.value) || 0.08;
+      updateRouteProfileBars();
+    });
+  }
+}
+
+function bindSelect(id, key) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.value = options[key];
+  el.addEventListener('change', (e) => {
+    options[key] = e.target.value;
+    updateRouteProfileBars();
+  });
+}
+
+function populateSelectors() {
+  const valueSel = document.getElementById(IDS.value);
+  if (valueSel && valueSel.options.length === 0) {
+    Object.entries(PROFILE_VALUES).forEach(([key, def]) => {
+      const opt = document.createElement('option');
+      opt.value = key;
+      opt.textContent = def.unit ? `${def.label} (${def.unit})` : def.label;
+      valueSel.appendChild(opt);
+    });
+  }
+  const schemeSel = document.getElementById(IDS.scheme);
+  if (schemeSel && schemeSel.options.length === 0) {
+    Object.entries(COLOR_SCHEMES).forEach(([key, def]) => {
+      const opt = document.createElement('option');
+      opt.value = key;
+      opt.textContent = def.label;
+      schemeSel.appendChild(opt);
+    });
+  }
+}
+
+/**
+ * Recompute and render the bars from the current route. No-op (clears) when the
+ * feature is disabled or there is no route. Called on route change and whenever
+ * a control changes.
+ */
+export function updateRouteProfileBars() {
+  if (!mapRef) return;
+  const barsSrc = mapRef.getSource(SOURCE_BARS);
+  const baselineSrc = mapRef.getSource(SOURCE_BASELINE);
+  if (!barsSrc || !baselineSrc) return;
+
+  const data = routeState.currentRouteData;
+  if (!options.enabled || !data || !Array.isArray(data.coordinates) || data.coordinates.length < 3) {
+    barsSrc.setData(emptyFC());
+    baselineSrc.setData(emptyFC());
+    renderLegend(null);
+    removeHandle();
+    return;
+  }
+
+  const series = getProfileSeries(data, options.valueKey);
+  if (!series.available || series.values.length === 0) {
+    barsSrc.setData(emptyFC());
+    baselineSrc.setData(emptyFC());
+    renderLegend({ unavailable: true, label: series.label });
+    removeHandle();
+    return;
+  }
+
+  // Elevation is continuous → average; discrete metrics keep the start value.
+  const mode = options.valueKey === 'elevation' ? 'avg' : 'start';
+  const segValues = toSegmentValues(series.values, mode);
+
+  // Geometry scale derived from the route length so the chart reads well at the
+  // whole-route view: ~90 uniform bars, baseline smoothed over ~3 bar widths.
+  const totalDistance = data.distance || 1;
+  const maxBarLengthMeters = Math.max(20, totalDistance * options.heightFactor);
+  const barWidthMeters = Math.max(8, totalDistance / 90);
+
+  // Offset the baseline a fixed ~40 px off the route at the current zoom (the
+  // bars are geographic, so we convert px -> meters here and rebuild on zoom).
+  const baseOffsetMeters = pixelsToMeters(BASELINE_OFFSET_PX, data.coordinates);
+
+  const result = buildProfileBars(data.coordinates, segValues, {
+    side: options.side,
+    maxBarLengthMeters,
+    barWidthMeters,
+    smoothingMeters: barWidthMeters * 6, // stronger smoothing -> cleaner baseline
+    baseOffsetMeters,
+    sampleStepMeters: Math.max(3, barWidthMeters / 4),
+    colorForT: (t) => colorForT(options.scheme, t),
+  });
+  lastBuiltZoom = mapRef.getZoom();
+
+  barsSrc.setData(result.bars);
+  baselineSrc.setData(result.baseline);
+  renderLegend({ minValue: result.domain.min, maxValue: result.domain.max, label: series.label, unit: series.unit });
+
+  // Keep the draggable handle in sync with the (possibly new) baseline geometry.
+  cursorGeom = {
+    baselineCoords: result.baseline.geometry.coordinates,
+    step: result.step,
+    routeCum: result.routeCum,
+  };
+  ensureHandleSubscription();
+  if (getCursorIndex() == null) {
+    // Show the handle at the route midpoint so it is there to grab.
+    setCursorIndex(Math.floor((data.coordinates.length - 1) / 2));
+  } else {
+    positionHandle(getCursorIndex());
+  }
+}
+
+function formatValue(n) {
+  if (!Number.isFinite(n)) return '–';
+  return Math.abs(n) >= 100 ? String(Math.round(n)) : String(Math.round(n * 10) / 10);
+}
+
+function renderLegend(info) {
+  const el = document.getElementById(IDS.legend);
+  if (!el) return;
+
+  if (!info) {
+    el.innerHTML = '';
+    el.style.display = 'none';
+    return;
+  }
+  el.style.display = 'block';
+
+  if (info.unavailable) {
+    el.innerHTML = `<div class="profile-bars-legend-empty">Keine ${info.label}-Daten für diese Route.</div>`;
+    return;
+  }
+
+  const unitSuffix = info.unit ? ` (${info.unit})` : '';
+  el.innerHTML = `
+    <div class="profile-bars-legend-row">
+      <span class="profile-bars-legend-label">${info.label}${unitSuffix}</span>
+    </div>
+    <div class="profile-bars-legend-gradient" style="background:${cssGradient(options.scheme)}"></div>
+    <div class="profile-bars-legend-row profile-bars-legend-scale">
+      <span>${formatValue(info.minValue)}</span>
+      <span>${formatValue(info.maxValue)}</span>
+    </div>`;
+}
+
+// ---------------------------------------------------------------------------
+// Draggable cursor handle on the barchart baseline
+// ---------------------------------------------------------------------------
+
+function ensureHandleSubscription() {
+  if (handleSubscribed) return;
+  onCursorChange((index) => positionHandle(index));
+  handleSubscribed = true;
+}
+
+// Point on the smooth baseline for a given route-coordinate index.
+function baselinePointForIndex(index) {
+  if (!cursorGeom || index == null) return null;
+  const { baselineCoords, step, routeCum } = cursorGeom;
+  if (!baselineCoords.length || !routeCum.length || !step) return null;
+  const i = Math.max(0, Math.min(routeCum.length - 1, index));
+  const p = Math.max(0, Math.min(baselineCoords.length - 1, routeCum[i] / step));
+  const i0 = Math.floor(p);
+  const i1 = Math.min(baselineCoords.length - 1, i0 + 1);
+  const f = p - i0;
+  const a = baselineCoords[i0];
+  const b = baselineCoords[i1];
+  return [a[0] + f * (b[0] - a[0]), a[1] + f * (b[1] - a[1])];
+}
+
+// Nearest route-coordinate index for an arbitrary map point, by snapping to the
+// baseline first — used while dragging the handle.
+function nearestRouteIndexFromLngLat(pt) {
+  if (!cursorGeom) return null;
+  const { baselineCoords, step, routeCum } = cursorGeom;
+  if (!baselineCoords.length || !routeCum.length) return null;
+  let bestK = 0;
+  let bestD = Infinity;
+  for (let k = 0; k < baselineCoords.length; k++) {
+    const dx = baselineCoords[k][0] - pt[0];
+    const dy = baselineCoords[k][1] - pt[1];
+    const d = dx * dx + dy * dy;
+    if (d < bestD) {
+      bestD = d;
+      bestK = k;
+    }
+  }
+  const s = bestK * step;
+  let lo = 0;
+  let hi = routeCum.length - 1;
+  while (lo < hi) {
+    const m = (lo + hi) >> 1;
+    if (routeCum[m] < s) lo = m + 1;
+    else hi = m;
+  }
+  if (lo > 0 && Math.abs(routeCum[lo - 1] - s) <= Math.abs(routeCum[lo] - s)) return lo - 1;
+  return lo;
+}
+
+function ensureHandle() {
+  if (!mapRef || handleMarker) return;
+  const el = document.createElement('div');
+  el.className = 'profile-bars-handle';
+  handleMarker = new maplibregl.Marker({ element: el, draggable: true, anchor: 'center' });
+  handleMarker.on('drag', () => {
+    const ll = handleMarker.getLngLat();
+    const idx = nearestRouteIndexFromLngLat([ll.lng, ll.lat]);
+    if (idx != null) setCursorIndex(idx); // snaps the handle back onto the baseline
+  });
+}
+
+function positionHandle(index) {
+  if (!options.enabled) {
+    removeHandle();
+    return;
+  }
+  const pt = baselinePointForIndex(index);
+  if (!pt) {
+    removeHandle();
+    return;
+  }
+  ensureHandle();
+  handleMarker.setLngLat(pt);
+  if (!handleMarker._map && mapRef) handleMarker.addTo(mapRef);
+}
+
+function removeHandle() {
+  if (handleMarker) handleMarker.remove();
+}
+
+function setupHover(map) {
+  hoverPopup = new maplibregl.Popup({ closeButton: false, closeOnClick: false });
+
+  map.on('mousemove', LAYER_BARS_FILL, (e) => {
+    if (!options.enabled || !e.features || e.features.length === 0) return;
+    map.getCanvas().style.cursor = 'pointer';
+
+    const f = e.features[0];
+    const def = PROFILE_VALUES[options.valueKey];
+    const unit = def && def.unit ? ` ${def.unit}` : '';
+    const label = def ? def.label : '';
+    hoverPopup
+      .setLngLat(e.lngLat)
+      .setHTML(
+        `<div style="font-size:12px;line-height:1.4"><strong>${label}:</strong> ${formatValue(f.properties.value)}${unit}</div>`
+      )
+      .addTo(map);
+
+    // Move the shared cursor to this bar's position on the route.
+    if (f.properties.routeIndex != null) setCursorIndex(f.properties.routeIndex);
+  });
+
+  map.on('mouseleave', LAYER_BARS_FILL, () => {
+    map.getCanvas().style.cursor = '';
+    if (hoverPopup) hoverPopup.remove();
+  });
+}
+
+/** Clear bars, baseline, handle and legend (called when the route is cleared). */
+export function clearRouteProfileBars() {
+  if (!mapRef) return;
+  const barsSrc = mapRef.getSource(SOURCE_BARS);
+  const baselineSrc = mapRef.getSource(SOURCE_BASELINE);
+  if (barsSrc) barsSrc.setData(emptyFC());
+  if (baselineSrc) baselineSrc.setData(emptyFC());
+  renderLegend(null);
+  if (hoverPopup) hoverPopup.remove();
+  removeHandle();
+  cursorGeom = null;
+}

--- a/js/routing/routeProfile/routeProfileBars.js
+++ b/js/routing/routeProfile/routeProfileBars.js
@@ -32,9 +32,18 @@ const options = {
   enabled: false,
   valueKey: 'elevation',
   scheme: 'danger',
-  side: 'right',
+  side: 'east', // 'east' | 'west' (resolved to the route's east/west travel side)
   heightFactor: 0.05, // bar length at t=1 = heightFactor * total route distance
 };
+
+// Defaults used to keep shared URLs short (only non-defaults are serialized).
+const DEFAULTS = { valueKey: 'elevation', scheme: 'danger', side: 'east', heightFactor: 0.05 };
+
+// Notify listeners (e.g. the permalink) that a user-facing option changed, so the
+// shareable URL can be updated. Decoupled via a DOM event — no import cycle.
+function notifyChange() {
+  document.dispatchEvent(new Event('profilebars:change'));
+}
 
 // Screen-space gap between the route line and the baseline the bars sit on.
 const BASELINE_OFFSET_PX = 40;
@@ -65,6 +74,18 @@ function pixelsToMeters(px, coordinates) {
   const lat = latSum / coordinates.length;
   const mPerPx = (156543.03392 * Math.cos((lat * Math.PI) / 180)) / Math.pow(2, mapRef.getZoom());
   return px * mPerPx;
+}
+
+// Resolve a compass preference ('east'/'west') to a travel-relative side
+// ('right'/'left') for the geometry. The right-hand normal points net-east when
+// the route's overall heading is northward, so the route's net N/S displacement
+// decides which travel side is the east one. Passes 'right'/'left' through.
+function resolveSide(pref, coordinates) {
+  if (pref !== 'east' && pref !== 'west') return pref === 'left' ? 'left' : 'right';
+  const netNorth = coordinates[coordinates.length - 1][1] - coordinates[0][1];
+  const eastIsRight = netNorth >= 0;
+  if (pref === 'west') return eastIsRight ? 'left' : 'right';
+  return eastIsRight ? 'right' : 'left';
 }
 
 /**
@@ -159,6 +180,7 @@ function setupControls() {
       options.enabled = e.target.checked;
       if (controls) controls.style.display = options.enabled ? 'block' : 'none';
       updateRouteProfileBars();
+      notifyChange();
     });
   }
 
@@ -170,8 +192,9 @@ function setupControls() {
   if (height) {
     height.value = String(options.heightFactor);
     height.addEventListener('input', (e) => {
-      options.heightFactor = parseFloat(e.target.value) || 0.08;
+      options.heightFactor = parseFloat(e.target.value) || 0.05;
       updateRouteProfileBars();
+      notifyChange();
     });
   }
 }
@@ -183,6 +206,7 @@ function bindSelect(id, key) {
   el.addEventListener('change', (e) => {
     options[key] = e.target.value;
     updateRouteProfileBars();
+    notifyChange();
   });
 }
 
@@ -251,7 +275,7 @@ export function updateRouteProfileBars() {
   const baseOffsetMeters = pixelsToMeters(BASELINE_OFFSET_PX, data.coordinates);
 
   const result = buildProfileBars(data.coordinates, segValues, {
-    side: options.side,
+    side: resolveSide(options.side, data.coordinates),
     maxBarLengthMeters,
     barWidthMeters,
     smoothingMeters: barWidthMeters * 6, // stronger smoothing -> cleaner baseline
@@ -437,4 +461,57 @@ export function clearRouteProfileBars() {
   if (hoverPopup) hoverPopup.remove();
   removeHandle();
   cursorGeom = null;
+}
+
+// ---------------------------------------------------------------------------
+// Shareable URL state — read on first render, serialize on change
+// ---------------------------------------------------------------------------
+
+// Reflect `options` into the DOM controls (safe anytime; no-ops on missing nodes).
+function syncControlsFromOptions() {
+  const toggle = document.getElementById(IDS.toggle);
+  const controls = document.getElementById(IDS.controls);
+  if (toggle) toggle.checked = options.enabled;
+  if (controls) controls.style.display = options.enabled ? 'block' : 'none';
+  const val = document.getElementById(IDS.value);
+  if (val) val.value = options.valueKey;
+  const scheme = document.getElementById(IDS.scheme);
+  if (scheme) scheme.value = options.scheme;
+  const side = document.getElementById(IDS.side);
+  if (side) side.value = options.side;
+  const height = document.getElementById(IDS.height);
+  if (height) height.value = String(options.heightFactor);
+}
+
+/**
+ * URL params for the current state — only when enabled, and only the values that
+ * differ from the defaults, so shared links stay short. Returns `key=value`[].
+ */
+export function serializeProfileBarsParams() {
+  if (!options.enabled) return [];
+  const parts = ['pbars=1'];
+  if (options.valueKey !== DEFAULTS.valueKey) parts.push(`pbval=${options.valueKey}`);
+  if (options.scheme !== DEFAULTS.scheme) parts.push(`pbcolor=${options.scheme}`);
+  if (options.side !== DEFAULTS.side) parts.push(`pbside=${options.side}`);
+  if (Math.abs(options.heightFactor - DEFAULTS.heightFactor) > 1e-9) {
+    parts.push(`pbh=${options.heightFactor}`);
+  }
+  return parts;
+}
+
+/** Read state from URLSearchParams (called once on first render by the permalink). */
+export function applyProfileBarsParams(params) {
+  if (!params) return;
+  options.enabled = params.get('pbars') === '1';
+  const val = params.get('pbval');
+  if (val && PROFILE_VALUES[val]) options.valueKey = val;
+  const col = params.get('pbcolor');
+  if (col && COLOR_SCHEMES[col]) options.scheme = col;
+  const side = params.get('pbside');
+  if (side === 'east' || side === 'west' || side === 'left' || side === 'right') options.side = side;
+  const h = parseFloat(params.get('pbh'));
+  if (Number.isFinite(h) && h > 0) options.heightFactor = Math.min(0.15, Math.max(0.01, h));
+  // Reflect + redraw if the map/controls are already up (otherwise setup does it).
+  syncControlsFromOptions();
+  updateRouteProfileBars();
 }

--- a/js/routing/routeProfile3D/profileColumns.js
+++ b/js/routing/routeProfile3D/profileColumns.js
@@ -1,0 +1,157 @@
+// 3D route profile columns — pure, framework-agnostic.
+//
+// Turns a route value series into footprint polygons carrying a `height` (meters)
+// property, ready to render with a native MapLibre `fill-extrusion` layer: each
+// column is a small rectangle along a line, extruded vertically by its value.
+// Viewed with the camera pitched, the columns read as a 3D bar chart.
+//
+// No MapLibre / DOM dependency → portable to a React port.
+
+const M_PER_DEG_LAT = 111320;
+
+function makeProjector(coordinates) {
+  let latSum = 0;
+  for (const c of coordinates) latSum += c[1];
+  const lat0 = latSum / coordinates.length;
+  const lng0 = coordinates[0][0];
+  const mLng = 111320 * Math.cos((lat0 * Math.PI) / 180) || 1;
+  return {
+    toXY: ([lng, lat]) => [(lng - lng0) * mLng, (lat - lat0) * M_PER_DEG_LAT],
+    toLngLat: ([x, y]) => [lng0 + x / mLng, lat0 + y / M_PER_DEG_LAT],
+  };
+}
+
+const sub = (a, b) => [a[0] - b[0], a[1] - b[1]];
+function unit(v) {
+  const l = Math.hypot(v[0], v[1]) || 1;
+  return [v[0] / l, v[1] / l];
+}
+
+function cumulative(xy) {
+  const cum = [0];
+  for (let i = 1; i < xy.length; i++) cum.push(cum[i - 1] + Math.hypot(xy[i][0] - xy[i - 1][0], xy[i][1] - xy[i - 1][1]));
+  return cum;
+}
+
+/**
+ * Build 3D column footprints along a polyline.
+ *
+ * @param {Array<[number, number]>} polyline - line the columns stand on ([lng,lat])
+ * @param {(fraction: number) => (number|null)} valueAtFraction - value at a
+ *        normalized position (0..1) along the route (kept separate so the same
+ *        route values drive columns whether the line is the route or a baseline)
+ * @param {Object} opts
+ * @param {number} opts.minValue / opts.maxValue - value domain for height/color
+ * @param {number} [opts.barWidthMeters] - spacing/length of columns along the line
+ * @param {number} [opts.footprintDepthMeters] - column depth across the line
+ * @param {number} [opts.maxHeightMeters=250] - column height (meters) at value = max
+ * @param {(t:number, value:number)=>string} [opts.colorForT] - color per value
+ * @returns {{type:'FeatureCollection', features:Array}} fill-extrusion polygons
+ */
+export function buildColumns(polyline, valueAtFraction, opts = {}) {
+  const features = [];
+  if (!polyline || polyline.length < 2 || typeof valueAtFraction !== 'function') {
+    return { type: 'FeatureCollection', features };
+  }
+
+  const proj = makeProjector(polyline);
+  const xy = polyline.map(proj.toXY);
+  const cum = cumulative(xy);
+  const D = cum[cum.length - 1];
+  if (D < 1) return { type: 'FeatureCollection', features };
+
+  const barWidth = opts.barWidthMeters > 0 ? opts.barWidthMeters : Math.max(20, D / 120);
+  const depth = opts.footprintDepthMeters > 0 ? opts.footprintDepthMeters : barWidth * 0.7;
+  const maxH = opts.maxHeightMeters > 0 ? opts.maxHeightMeters : 250;
+  const minV = opts.minValue;
+  const maxV = opts.maxValue;
+  const range = maxV - minV || 1;
+  const colorFn = typeof opts.colorForT === 'function' ? opts.colorForT : null;
+  const gap = 0.82;
+
+  // Point + unit tangent at arc-length s along the (projected) polyline.
+  const at = (s) => {
+    if (s <= 0) return { p: xy[0], t: unit(sub(xy[1], xy[0])) };
+    if (s >= D) return { p: xy[xy.length - 1], t: unit(sub(xy[xy.length - 1], xy[xy.length - 2])) };
+    let lo = 0;
+    let hi = xy.length - 1;
+    while (lo < hi) {
+      const m = (lo + hi) >> 1;
+      if (cum[m] < s) lo = m + 1;
+      else hi = m;
+    }
+    const i1 = lo;
+    const i0 = Math.max(0, lo - 1);
+    const seg = cum[i1] - cum[i0] || 1;
+    const f = (s - cum[i0]) / seg;
+    return {
+      p: [xy[i0][0] + f * (xy[i1][0] - xy[i0][0]), xy[i0][1] + f * (xy[i1][1] - xy[i0][1])],
+      t: unit(sub(xy[i1], xy[i0])),
+    };
+  };
+
+  const numCols = Math.max(1, Math.floor(D / barWidth));
+  const barW = D / numCols;
+
+  for (let j = 0; j < numCols; j++) {
+    const sMid = (j + 0.5) * barW;
+    const value = valueAtFraction(sMid / D);
+    if (value == null || !Number.isFinite(value)) continue;
+
+    const t = Math.max(0, Math.min(1, (value - minV) / range));
+    const height = t * maxH;
+    if (height <= 0) continue;
+
+    const { p, t: tan } = at(sMid);
+    const nor = [tan[1], -tan[0]];
+    const hw = (barWidth * gap) / 2;
+    const hd = depth / 2;
+
+    const c1 = [p[0] + tan[0] * hw + nor[0] * hd, p[1] + tan[1] * hw + nor[1] * hd];
+    const c2 = [p[0] + tan[0] * hw - nor[0] * hd, p[1] + tan[1] * hw - nor[1] * hd];
+    const c3 = [p[0] - tan[0] * hw - nor[0] * hd, p[1] - tan[1] * hw - nor[1] * hd];
+    const c4 = [p[0] - tan[0] * hw + nor[0] * hd, p[1] - tan[1] * hw + nor[1] * hd];
+    const ring = [c1, c2, c3, c4, c1].map(proj.toLngLat);
+
+    features.push({
+      type: 'Feature',
+      geometry: { type: 'Polygon', coordinates: [ring] },
+      properties: {
+        index: j,
+        value,
+        t,
+        height: Math.round(height * 10) / 10,
+        color: colorFn ? colorFn(t, value) : '#7c3aed',
+      },
+    });
+  }
+
+  return { type: 'FeatureCollection', features };
+}
+
+/**
+ * Build a `valueAtFraction(f)` sampler from a route and its per-coordinate values
+ * (piecewise-constant by arc-length). f is normalized progress along the route.
+ * @param {Array<[number, number]>} coordinates
+ * @param {Array<number|null>} perCoordValues
+ * @returns {(f:number)=>(number|null)}
+ */
+export function makeValueAtFraction(coordinates, perCoordValues) {
+  if (!coordinates || coordinates.length < 2) return () => null;
+  const proj = makeProjector(coordinates);
+  const cum = cumulative(coordinates.map(proj.toXY));
+  const L = cum[cum.length - 1] || 1;
+  return (f) => {
+    const s = Math.max(0, Math.min(1, f)) * L;
+    let lo = 0;
+    let hi = cum.length - 1;
+    while (lo < hi) {
+      const m = (lo + hi) >> 1;
+      if (cum[m] < s) lo = m + 1;
+      else hi = m;
+    }
+    const idx = Math.max(0, lo - 1);
+    const v = perCoordValues[idx];
+    return v == null || !Number.isFinite(v) ? null : v;
+  };
+}

--- a/js/routing/routeProfile3D/routeProfile3D.js
+++ b/js/routing/routeProfile3D/routeProfile3D.js
@@ -36,10 +36,17 @@ const options = {
   buildings: true,
 };
 
+// Defaults used to keep shared URLs short (only non-defaults are serialized).
+const DEFAULTS = { variant: 'route', valueKey: 'elevation', scheme: 'danger', maxHeightMeters: 250, buildings: true };
+
 const ENABLED_PITCH = 55;
 let mapRef = null;
 let controlsWired = false;
-let prevPitch = 0;
+
+// Notify listeners (the permalink) that a user-facing 3D option changed.
+function notifyChange() {
+  document.dispatchEvent(new Event('profile3d:change'));
+}
 
 function emptyFC() {
   return { type: 'FeatureCollection', features: [] };
@@ -53,6 +60,8 @@ export function setupRouteProfile3D(map) {
     controlsWired = true;
   }
   update3D();
+  // Restore the tilted view when arriving with 3D enabled (e.g. from a shared URL).
+  if (options.enabled) applyCamera();
 }
 
 function ensureLayers(map) {
@@ -110,6 +119,7 @@ function setupControls() {
       if (controls) controls.style.display = options.enabled ? 'block' : 'none';
       applyCamera();
       update3D();
+      notifyChange();
     });
   }
 
@@ -123,6 +133,7 @@ function setupControls() {
     height.addEventListener('input', (e) => {
       options.maxHeightMeters = parseFloat(e.target.value) || 250;
       update3D();
+      notifyChange();
     });
   }
 
@@ -132,6 +143,7 @@ function setupControls() {
     buildings.addEventListener('change', (e) => {
       options.buildings = e.target.checked;
       updateBuildingsVisibility();
+      notifyChange();
     });
   }
 }
@@ -143,6 +155,7 @@ function bindSelect(id, key) {
   el.addEventListener('change', (e) => {
     options[key] = e.target.value;
     update3D();
+    notifyChange();
   });
 }
 
@@ -167,14 +180,13 @@ function populateSelectors() {
   }
 }
 
-// Tilt the camera into a 3D view when enabling, restore when disabling.
+// Tilt the camera into a 3D view when enabling, flatten it when disabling.
 function applyCamera() {
   if (!mapRef) return;
   if (options.enabled) {
-    prevPitch = mapRef.getPitch();
     if (mapRef.getPitch() < 30) mapRef.easeTo({ pitch: ENABLED_PITCH, duration: 600 });
   } else {
-    mapRef.easeTo({ pitch: prevPitch || 0, duration: 600 });
+    mapRef.easeTo({ pitch: 0, duration: 600 });
   }
 }
 
@@ -254,4 +266,55 @@ export function clearRouteProfile3D() {
   const src = mapRef.getSource(SOURCE_COLS);
   if (src) src.setData(emptyFC());
   updateBuildingsVisibility();
+}
+
+// ---------------------------------------------------------------------------
+// Shareable URL state — read on first render, serialize on change
+// ---------------------------------------------------------------------------
+
+// Reflect `options` into the DOM controls (safe anytime; no-ops on missing nodes).
+function syncControlsFromOptions() {
+  const set = (id, v) => { const el = document.getElementById(id); if (el) el.value = v; };
+  const setChecked = (id, v) => { const el = document.getElementById(id); if (el) el.checked = v; };
+  setChecked(IDS.toggle, options.enabled);
+  const controls = document.getElementById(IDS.controls);
+  if (controls) controls.style.display = options.enabled ? 'block' : 'none';
+  set(IDS.variant, options.variant);
+  set(IDS.value, options.valueKey);
+  set(IDS.scheme, options.scheme);
+  set(IDS.height, String(options.maxHeightMeters));
+  setChecked(IDS.buildings, options.buildings);
+}
+
+/** URL params for the current 3D state — only when enabled, only non-defaults. */
+export function serializeProfile3DParams() {
+  if (!options.enabled) return [];
+  const parts = ['p3d=1'];
+  if (options.variant !== DEFAULTS.variant) parts.push(`p3dvar=${options.variant}`);
+  if (options.valueKey !== DEFAULTS.valueKey) parts.push(`p3dval=${options.valueKey}`);
+  if (options.scheme !== DEFAULTS.scheme) parts.push(`p3dcolor=${options.scheme}`);
+  if (options.maxHeightMeters !== DEFAULTS.maxHeightMeters) parts.push(`p3dh=${options.maxHeightMeters}`);
+  if (options.buildings !== DEFAULTS.buildings) parts.push(`p3dbld=${options.buildings ? 1 : 0}`);
+  return parts;
+}
+
+/** Read 3D state from URLSearchParams (called once on first render by the permalink). */
+export function applyProfile3DParams(params) {
+  if (!params) return;
+  options.enabled = params.get('p3d') === '1';
+  const variant = params.get('p3dvar');
+  if (variant === 'route' || variant === 'baseline') options.variant = variant;
+  const val = params.get('p3dval');
+  if (val && PROFILE_VALUES[val]) options.valueKey = val;
+  const col = params.get('p3dcolor');
+  if (col && COLOR_SCHEMES[col]) options.scheme = col;
+  const h = parseFloat(params.get('p3dh'));
+  if (Number.isFinite(h) && h > 0) options.maxHeightMeters = Math.min(800, Math.max(50, h));
+  const bld = params.get('p3dbld');
+  if (bld === '0') options.buildings = false;
+  else if (bld === '1') options.buildings = true;
+  // Reflect + redraw if the map/controls are already up (otherwise setup does it).
+  syncControlsFromOptions();
+  update3D();
+  if (options.enabled) applyCamera();
 }

--- a/js/routing/routeProfile3D/routeProfile3D.js
+++ b/js/routing/routeProfile3D/routeProfile3D.js
@@ -35,11 +35,12 @@ const options = {
   scheme: 'danger',
   maxHeightMeters: 250,
   buildings: true,
-  terrain: false,
+  terrain: true,
 };
 
 // Defaults used to keep shared URLs short (only non-defaults are serialized).
-const DEFAULTS = { variant: 'route', valueKey: 'elevation', scheme: 'danger', maxHeightMeters: 250, buildings: true, terrain: false };
+// buildings + terrain default ON: activating 3D turns the whole 3D scene on.
+const DEFAULTS = { variant: 'route', valueKey: 'elevation', scheme: 'danger', maxHeightMeters: 250, buildings: true, terrain: true };
 
 // 3D terrain look, aligned with the gradients2osm reference (Mapterhorn DEM +
 // blue atmospheric sky). The app already provides the 'terrain' raster-dem source.
@@ -137,6 +138,12 @@ function setupControls() {
     toggle.addEventListener('change', (e) => {
       options.enabled = e.target.checked;
       if (controls) controls.style.display = options.enabled ? 'block' : 'none';
+      // Activating the 3D graph also activates the 3D buildings + terrain scene.
+      if (options.enabled) {
+        options.buildings = true;
+        options.terrain = true;
+        syncControlsFromOptions();
+      }
       applyCamera();
       applyTerrain();
       update3D();

--- a/js/routing/routeProfile3D/routeProfile3D.js
+++ b/js/routing/routeProfile3D/routeProfile3D.js
@@ -1,0 +1,257 @@
+// 3D route profile — native MapLibre 3D bar chart (fill-extrusion) + optional
+// 3D buildings, tilted camera view. Two variants:
+//   - 'route'    : columns stand on the route itself
+//   - 'baseline' : columns stand on a smoothed baseline beside the route
+//
+// This is the ONLY module here that touches MapLibre/DOM. Geometry, values and
+// colors live in pure modules (profileColumns + the shared profileValues /
+// profileColorScales), so a React port only re-implements this thin layer.
+
+import { routeState } from '../routeState.js';
+import { buildColumns, makeValueAtFraction } from './profileColumns.js';
+import { buildProfileBars } from '../routeProfile/profileGeometry.js';
+import { PROFILE_VALUES, getProfileSeries, toSegmentValues } from '../routeProfile/profileValues.js';
+import { COLOR_SCHEMES, colorForT } from '../routeProfile/profileColorScales.js';
+
+const SOURCE_COLS = 'route-3d-columns';
+const LAYER_COLS = 'route-3d-columns-extrusion';
+const LAYER_BUILDINGS = 'route-3d-buildings';
+
+const IDS = {
+  toggle: 'profile3d-toggle',
+  controls: 'profile3d-controls',
+  variant: 'profile3d-variant',
+  value: 'profile3d-value',
+  scheme: 'profile3d-scheme',
+  height: 'profile3d-height',
+  buildings: 'profile3d-buildings',
+};
+
+const options = {
+  enabled: false,
+  variant: 'route', // 'route' | 'baseline'
+  valueKey: 'elevation',
+  scheme: 'danger',
+  maxHeightMeters: 250,
+  buildings: true,
+};
+
+const ENABLED_PITCH = 55;
+let mapRef = null;
+let controlsWired = false;
+let prevPitch = 0;
+
+function emptyFC() {
+  return { type: 'FeatureCollection', features: [] };
+}
+
+export function setupRouteProfile3D(map) {
+  mapRef = map;
+  ensureLayers(map);
+  if (!controlsWired) {
+    setupControls();
+    controlsWired = true;
+  }
+  update3D();
+}
+
+function ensureLayers(map) {
+  if (!map.getSource(SOURCE_COLS)) {
+    map.addSource(SOURCE_COLS, { type: 'geojson', data: emptyFC() });
+  }
+  // 3D buildings reuse the basemap's existing OpenMapTiles `building` source-layer
+  // (render_height / render_min_height), extruded natively. Hidden until toggled.
+  if (map.getSource('openmaptiles') && !map.getLayer(LAYER_BUILDINGS)) {
+    map.addLayer({
+      id: LAYER_BUILDINGS,
+      type: 'fill-extrusion',
+      source: 'openmaptiles',
+      'source-layer': 'building',
+      minzoom: 13,
+      layout: { visibility: 'none' },
+      paint: {
+        'fill-extrusion-color': 'hsl(35, 8%, 80%)',
+        'fill-extrusion-height': [
+          'max',
+          ['coalesce', ['to-number', ['get', 'render_height']], 6],
+          ['coalesce', ['to-number', ['get', 'render_min_height']], 0],
+        ],
+        'fill-extrusion-base': ['coalesce', ['to-number', ['get', 'render_min_height']], 0],
+        'fill-extrusion-opacity': 0.75,
+      },
+    });
+  }
+  // The route profile columns sit on top, depth-tested against the buildings.
+  if (!map.getLayer(LAYER_COLS)) {
+    map.addLayer({
+      id: LAYER_COLS,
+      type: 'fill-extrusion',
+      source: SOURCE_COLS,
+      paint: {
+        'fill-extrusion-color': ['get', 'color'],
+        'fill-extrusion-height': ['get', 'height'],
+        'fill-extrusion-base': 0,
+        'fill-extrusion-opacity': 0.92,
+      },
+    });
+  }
+}
+
+function setupControls() {
+  populateSelectors();
+
+  const toggle = document.getElementById(IDS.toggle);
+  const controls = document.getElementById(IDS.controls);
+  if (toggle) {
+    toggle.checked = options.enabled;
+    if (controls) controls.style.display = options.enabled ? 'block' : 'none';
+    toggle.addEventListener('change', (e) => {
+      options.enabled = e.target.checked;
+      if (controls) controls.style.display = options.enabled ? 'block' : 'none';
+      applyCamera();
+      update3D();
+    });
+  }
+
+  bindSelect(IDS.variant, 'variant');
+  bindSelect(IDS.value, 'valueKey');
+  bindSelect(IDS.scheme, 'scheme');
+
+  const height = document.getElementById(IDS.height);
+  if (height) {
+    height.value = String(options.maxHeightMeters);
+    height.addEventListener('input', (e) => {
+      options.maxHeightMeters = parseFloat(e.target.value) || 250;
+      update3D();
+    });
+  }
+
+  const buildings = document.getElementById(IDS.buildings);
+  if (buildings) {
+    buildings.checked = options.buildings;
+    buildings.addEventListener('change', (e) => {
+      options.buildings = e.target.checked;
+      updateBuildingsVisibility();
+    });
+  }
+}
+
+function bindSelect(id, key) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.value = options[key];
+  el.addEventListener('change', (e) => {
+    options[key] = e.target.value;
+    update3D();
+  });
+}
+
+function populateSelectors() {
+  const valueSel = document.getElementById(IDS.value);
+  if (valueSel && valueSel.options.length === 0) {
+    Object.entries(PROFILE_VALUES).forEach(([key, def]) => {
+      const opt = document.createElement('option');
+      opt.value = key;
+      opt.textContent = def.unit ? `${def.label} (${def.unit})` : def.label;
+      valueSel.appendChild(opt);
+    });
+  }
+  const schemeSel = document.getElementById(IDS.scheme);
+  if (schemeSel && schemeSel.options.length === 0) {
+    Object.entries(COLOR_SCHEMES).forEach(([key, def]) => {
+      const opt = document.createElement('option');
+      opt.value = key;
+      opt.textContent = def.label;
+      schemeSel.appendChild(opt);
+    });
+  }
+}
+
+// Tilt the camera into a 3D view when enabling, restore when disabling.
+function applyCamera() {
+  if (!mapRef) return;
+  if (options.enabled) {
+    prevPitch = mapRef.getPitch();
+    if (mapRef.getPitch() < 30) mapRef.easeTo({ pitch: ENABLED_PITCH, duration: 600 });
+  } else {
+    mapRef.easeTo({ pitch: prevPitch || 0, duration: 600 });
+  }
+}
+
+function updateBuildingsVisibility() {
+  if (!mapRef || !mapRef.getLayer(LAYER_BUILDINGS)) return;
+  const vis = options.enabled && options.buildings ? 'visible' : 'none';
+  mapRef.setLayoutProperty(LAYER_BUILDINGS, 'visibility', vis);
+}
+
+// Meters per pixel at the current zoom (for a baseline offset that reads ~constant).
+function pixelsToMeters(px, coordinates) {
+  if (!mapRef || !coordinates.length) return px;
+  let latSum = 0;
+  for (const c of coordinates) latSum += c[1];
+  const lat = latSum / coordinates.length;
+  const mPerPx = (156543.03392 * Math.cos((lat * Math.PI) / 180)) / Math.pow(2, mapRef.getZoom());
+  return px * mPerPx;
+}
+
+export function update3D() {
+  if (!mapRef) return;
+  const src = mapRef.getSource(SOURCE_COLS);
+  if (!src) return;
+
+  updateBuildingsVisibility();
+
+  const data = routeState.currentRouteData;
+  if (!options.enabled || !data || !Array.isArray(data.coordinates) || data.coordinates.length < 3) {
+    src.setData(emptyFC());
+    return;
+  }
+
+  const series = getProfileSeries(data, options.valueKey);
+  if (!series.available || series.values.length === 0) {
+    src.setData(emptyFC());
+    return;
+  }
+
+  const valueAtFraction = makeValueAtFraction(data.coordinates, series.values);
+  const valid = series.values.filter((v) => Number.isFinite(v));
+  const minValue = valid.length ? Math.min(...valid) : 0;
+  const maxValue = valid.length ? Math.max(...valid) : 1;
+
+  const totalDistance = data.distance || 1;
+  const barWidthMeters = Math.max(15, totalDistance / 200);
+
+  // Which line do the columns stand on?
+  let line = data.coordinates;
+  if (options.variant === 'baseline') {
+    const mode = options.valueKey === 'elevation' ? 'avg' : 'start';
+    const segValues = toSegmentValues(series.values, mode);
+    const baseline = buildProfileBars(data.coordinates, segValues, {
+      side: 'east',
+      maxBarLengthMeters: 1,
+      barWidthMeters,
+      smoothingMeters: barWidthMeters * 8,
+      baseOffsetMeters: pixelsToMeters(70, data.coordinates),
+      sampleStepMeters: Math.max(3, barWidthMeters / 4),
+    }).baseline;
+    if (baseline && baseline.geometry.coordinates.length > 1) line = baseline.geometry.coordinates;
+  }
+
+  const fc = buildColumns(line, valueAtFraction, {
+    minValue,
+    maxValue,
+    barWidthMeters,
+    footprintDepthMeters: barWidthMeters * 0.7,
+    maxHeightMeters: options.maxHeightMeters,
+    colorForT: (t) => colorForT(options.scheme, t),
+  });
+  src.setData(fc);
+}
+
+/** Clear columns + reset the camera/buildings (called when the route is cleared). */
+export function clearRouteProfile3D() {
+  if (!mapRef) return;
+  const src = mapRef.getSource(SOURCE_COLS);
+  if (src) src.setData(emptyFC());
+  updateBuildingsVisibility();
+}

--- a/js/routing/routeProfile3D/routeProfile3D.js
+++ b/js/routing/routeProfile3D/routeProfile3D.js
@@ -25,6 +25,7 @@ const IDS = {
   scheme: 'profile3d-scheme',
   height: 'profile3d-height',
   buildings: 'profile3d-buildings',
+  terrain: 'profile3d-terrain',
 };
 
 const options = {
@@ -34,14 +35,30 @@ const options = {
   scheme: 'danger',
   maxHeightMeters: 250,
   buildings: true,
+  terrain: false,
 };
 
 // Defaults used to keep shared URLs short (only non-defaults are serialized).
-const DEFAULTS = { variant: 'route', valueKey: 'elevation', scheme: 'danger', maxHeightMeters: 250, buildings: true };
+const DEFAULTS = { variant: 'route', valueKey: 'elevation', scheme: 'danger', maxHeightMeters: 250, buildings: true, terrain: false };
+
+// 3D terrain look, aligned with the gradients2osm reference (Mapterhorn DEM +
+// blue atmospheric sky). The app already provides the 'terrain' raster-dem source.
+const TERRAIN_SOURCE = 'terrain';
+const TERRAIN_EXAGGERATION = 1.5;
+const SKY_STYLE = {
+  'sky-color': '#199EF3',
+  'sky-horizon-blend': 0.7,
+  'horizon-color': '#f0f8ff',
+  'horizon-fog-blend': 0.8,
+  'fog-color': '#2c7fb8',
+  'fog-ground-blend': 0.9,
+  'atmosphere-blend': ['interpolate', ['linear'], ['zoom'], 0, 1, 10, 1, 13, 0],
+};
 
 const ENABLED_PITCH = 55;
 let mapRef = null;
 let controlsWired = false;
+let terrainAppliedByUs = false;
 
 // Notify listeners (the permalink) that a user-facing 3D option changed.
 function notifyChange() {
@@ -60,8 +77,11 @@ export function setupRouteProfile3D(map) {
     controlsWired = true;
   }
   update3D();
-  // Restore the tilted view when arriving with 3D enabled (e.g. from a shared URL).
-  if (options.enabled) applyCamera();
+  // Restore the tilted view (+ terrain) when arriving with 3D enabled from a URL.
+  if (options.enabled) {
+    applyCamera();
+    applyTerrain();
+  }
 }
 
 function ensureLayers(map) {
@@ -118,6 +138,7 @@ function setupControls() {
       options.enabled = e.target.checked;
       if (controls) controls.style.display = options.enabled ? 'block' : 'none';
       applyCamera();
+      applyTerrain();
       update3D();
       notifyChange();
     });
@@ -143,6 +164,16 @@ function setupControls() {
     buildings.addEventListener('change', (e) => {
       options.buildings = e.target.checked;
       updateBuildingsVisibility();
+      notifyChange();
+    });
+  }
+
+  const terrain = document.getElementById(IDS.terrain);
+  if (terrain) {
+    terrain.checked = options.terrain;
+    terrain.addEventListener('change', (e) => {
+      options.terrain = e.target.checked;
+      applyTerrain();
       notifyChange();
     });
   }
@@ -187,6 +218,24 @@ function applyCamera() {
     if (mapRef.getPitch() < 30) mapRef.easeTo({ pitch: ENABLED_PITCH, duration: 600 });
   } else {
     mapRef.easeTo({ pitch: 0, duration: 600 });
+  }
+}
+
+// 3D terrain mesh + atmospheric sky (gradients2osm style). Only removes terrain
+// we ourselves added, so it doesn't clobber the separate map-settings terrain.
+function applyTerrain() {
+  if (!mapRef) return;
+  const on = options.enabled && options.terrain;
+  if (on) {
+    if (mapRef.getSource(TERRAIN_SOURCE)) {
+      mapRef.setTerrain({ source: TERRAIN_SOURCE, exaggeration: TERRAIN_EXAGGERATION });
+    }
+    if (typeof mapRef.setSky === 'function') mapRef.setSky(SKY_STYLE);
+    terrainAppliedByUs = true;
+  } else if (terrainAppliedByUs) {
+    mapRef.setTerrain(null);
+    if (typeof mapRef.setSky === 'function') mapRef.setSky(undefined);
+    terrainAppliedByUs = false;
   }
 }
 
@@ -284,6 +333,7 @@ function syncControlsFromOptions() {
   set(IDS.scheme, options.scheme);
   set(IDS.height, String(options.maxHeightMeters));
   setChecked(IDS.buildings, options.buildings);
+  setChecked(IDS.terrain, options.terrain);
 }
 
 /** URL params for the current 3D state — only when enabled, only non-defaults. */
@@ -295,6 +345,7 @@ export function serializeProfile3DParams() {
   if (options.scheme !== DEFAULTS.scheme) parts.push(`p3dcolor=${options.scheme}`);
   if (options.maxHeightMeters !== DEFAULTS.maxHeightMeters) parts.push(`p3dh=${options.maxHeightMeters}`);
   if (options.buildings !== DEFAULTS.buildings) parts.push(`p3dbld=${options.buildings ? 1 : 0}`);
+  if (options.terrain !== DEFAULTS.terrain) parts.push(`p3dterr=${options.terrain ? 1 : 0}`);
   return parts;
 }
 
@@ -313,8 +364,14 @@ export function applyProfile3DParams(params) {
   const bld = params.get('p3dbld');
   if (bld === '0') options.buildings = false;
   else if (bld === '1') options.buildings = true;
+  const terr = params.get('p3dterr');
+  if (terr === '1') options.terrain = true;
+  else if (terr === '0') options.terrain = false;
   // Reflect + redraw if the map/controls are already up (otherwise setup does it).
   syncControlsFromOptions();
   update3D();
-  if (options.enabled) applyCamera();
+  if (options.enabled) {
+    applyCamera();
+    applyTerrain();
+  }
 }

--- a/js/routing/routing.js
+++ b/js/routing/routing.js
@@ -6,6 +6,7 @@ import { setupUIHandlers } from './routingUI.js';
 import { setupHeightgraphHandlers, drawHeightgraph, cleanupHeightgraphHandlers } from './heightgraph.js';
 import { setupRouteHover, updateRouteColor } from './routeVisualization.js';
 import { setupRouteProfileBars, updateRouteProfileBars, clearRouteProfileBars } from './routeProfile/routeProfileBars.js';
+import { setupRouteProfile3D, update3D, clearRouteProfile3D } from './routeProfile3D/routeProfile3D.js';
 import { clearCursor } from './routeCursor.js';
 import {
   supportsCustomModel,
@@ -597,6 +598,7 @@ export function setupRouting(map) {
   setupUIHandlers(map);
   setupHeightgraphHandlers();
   setupRouteProfileBars(map);
+  setupRouteProfile3D(map);
 
   // Automatically activate start point selection mode on map load
   // BUT only if no points were loaded from permalink
@@ -1023,6 +1025,9 @@ export async function calculateRoute(map, start, end, waypoints = []) {
         // Update on-map route profile bars (perpendicular histogram)
         updateRouteProfileBars();
 
+        // Update 3D route profile (fill-extrusion columns)
+        update3D();
+
         // Calculate comparison with Weight=1 if current weight < 1
         if (supportsCustomModel(routeState.selectedProfile) && routeState.customModel) {
           const currentWeight = getMapillaryPriority(routeState.customModel);
@@ -1109,8 +1114,9 @@ export function clearRoute(map) {
   // Cleanup heightgraph event handlers
   cleanupHeightgraphHandlers();
 
-  // Clear on-map route profile bars and the shared cursor
+  // Clear on-map route profile bars, 3D columns, and the shared cursor
   clearRouteProfileBars();
+  clearRouteProfile3D();
   clearCursor();
 
   routeState.reset();

--- a/js/routing/routing.js
+++ b/js/routing/routing.js
@@ -5,6 +5,8 @@ import { routeState } from './routeState.js';
 import { setupUIHandlers } from './routingUI.js';
 import { setupHeightgraphHandlers, drawHeightgraph, cleanupHeightgraphHandlers } from './heightgraph.js';
 import { setupRouteHover, updateRouteColor } from './routeVisualization.js';
+import { setupRouteProfileBars, updateRouteProfileBars, clearRouteProfileBars } from './routeProfile/routeProfileBars.js';
+import { clearCursor } from './routeCursor.js';
 import {
   supportsCustomModel,
   getGraphHopperProfile,
@@ -594,7 +596,8 @@ export function setupRouting(map) {
 
   setupUIHandlers(map);
   setupHeightgraphHandlers();
-  
+  setupRouteProfileBars(map);
+
   // Automatically activate start point selection mode on map load
   // BUT only if no points were loaded from permalink
   if (!routeState.startPoint && !routeState.endPoint) {
@@ -1016,7 +1019,10 @@ export async function calculateRoute(map, start, end, waypoints = []) {
         
         // Update route color based on current selection
         updateRouteColor(routeState.currentEncodedType, encodedValues);
-        
+
+        // Update on-map route profile bars (perpendicular histogram)
+        updateRouteProfileBars();
+
         // Calculate comparison with Weight=1 if current weight < 1
         if (supportsCustomModel(routeState.selectedProfile) && routeState.customModel) {
           const currentWeight = getMapillaryPriority(routeState.customModel);
@@ -1102,7 +1108,11 @@ export async function calculateRoute(map, start, end, waypoints = []) {
 export function clearRoute(map) {
   // Cleanup heightgraph event handlers
   cleanupHeightgraphHandlers();
-  
+
+  // Clear on-map route profile bars and the shared cursor
+  clearRouteProfileBars();
+  clearCursor();
+
   routeState.reset();
   if (map && map.getCanvas()) {
     map.getCanvas().style.cursor = '';

--- a/js/utils/permalink.js
+++ b/js/utils/permalink.js
@@ -18,6 +18,7 @@ import {
 } from '../routing/customModel.js';
 import { MAPILLARY_SLIDER_VALUES, PERMALINK as PERMALINK_CONFIG } from './constants.js';
 import { serializeProfileBarsParams, applyProfileBarsParams } from '../routing/routeProfile/routeProfileBars.js';
+import { serializeProfile3DParams, applyProfile3DParams } from '../routing/routeProfile3D/routeProfile3D.js';
 
 export class Permalink {
   constructor(map) {
@@ -49,8 +50,9 @@ export class Permalink {
     this.setupRouteStateListeners();
     this.setupContextLayerListeners();
 
-    // Route profile bars settings changed → reflect into the shareable URL.
+    // Route profile (2D bars / 3D columns) settings changed → update the URL.
     document.addEventListener('profilebars:change', () => this.updateURL());
+    document.addEventListener('profile3d:change', () => this.updateURL());
   }
 
   setupRouteStateListeners() {
@@ -206,8 +208,9 @@ export class Permalink {
       paramParts.push('missingStreets=1');
     }
 
-    // Route profile bars settings
+    // Route profile bars (2D) + 3D columns settings
     paramParts.push(...serializeProfileBarsParams());
+    paramParts.push(...serializeProfile3DParams());
 
     const newURL = `${window.location.pathname}?${paramParts.join('&')}`;
     window.history.replaceState({}, '', newURL);
@@ -216,9 +219,10 @@ export class Permalink {
   async loadFromURL() {
     const params = new URLSearchParams(window.location.search);
 
-    // Route profile bars settings — set options now so setupRouteProfileBars (on
-    // map load) reflects them in the UI and renders once the route is available.
+    // Route profile bars (2D) + 3D columns settings — set options now so the
+    // setup (on map load) reflects them in the UI and renders with the route.
     applyProfileBarsParams(params);
+    applyProfile3DParams(params);
 
     // Load map state
     const mapParam = params.get('map');
@@ -747,6 +751,7 @@ export class Permalink {
     }
 
     paramParts.push(...serializeProfileBarsParams());
+    paramParts.push(...serializeProfile3DParams());
 
     return `${window.location.origin}${window.location.pathname}?${paramParts.join('&')}`;
   }

--- a/js/utils/permalink.js
+++ b/js/utils/permalink.js
@@ -25,6 +25,7 @@ export class Permalink {
     this.map = map;
     this.isUpdating = false;
     this.pendingRouteCalculation = false; // Flag to track if route should be calculated after map loads
+    this.pendingBasemap = null; // basemap from the URL, until its restore lands (avoids a transient URL strip)
     this.setupEventListeners();
     // Load from URL asynchronously (don't await to avoid blocking constructor)
     this.loadFromURL().catch(err => {
@@ -113,6 +114,15 @@ export class Permalink {
       currentEncodedType: routeState.currentEncodedType,
       customModel: routeState.customModel
     };
+  }
+
+  // Currently selected basemap ("map background"): standard | dark | osm | satellite.
+  getCurrentBasemap() {
+    // Hold the URL's value until its deferred restore has actually switched the basemap.
+    if (this.pendingBasemap) return this.pendingBasemap;
+    const el = document.querySelector('.basemap-btn.selected, .basemap-thumb.selected');
+    const map = el && el.dataset ? el.dataset.map : null;
+    return ['standard', 'dark', 'osm', 'satellite'].includes(map) ? map : 'standard';
   }
 
   updateURL() {
@@ -207,6 +217,10 @@ export class Permalink {
     if (toggleMissingStreets && toggleMissingStreets.checked) {
       paramParts.push('missingStreets=1');
     }
+
+    // Map background (basemap) — only when not the default
+    const basemap = this.getCurrentBasemap();
+    if (basemap !== 'standard') paramParts.push(`basemap=${basemap}`);
 
     // Route profile bars (2D) + 3D columns settings
     paramParts.push(...serializeProfileBarsParams());
@@ -611,6 +625,24 @@ export class Permalink {
       }
     }
     
+    // Restore the basemap ("map background"). Done after the map has loaded by
+    // triggering the basemap button's own click handler (it does the theme /
+    // setStyle switching and route restore). 'standard' is the default → skip.
+    const basemapParam = params.get('basemap');
+    if (['dark', 'osm', 'satellite'].includes(basemapParam)) {
+      this.pendingBasemap = basemapParam; // keep it in the URL until the restore lands
+      const restoreBasemap = () => {
+        const btn = document.querySelector(`.basemap-btn[data-map="${basemapParam}"]`);
+        if (btn && !btn.classList.contains('selected')) btn.click();
+        this.pendingBasemap = null;
+      };
+      if (this.map.loaded()) {
+        setTimeout(restoreBasemap, PERMALINK_CONFIG.LAYER_ACTIVATION_DELAY);
+      } else {
+        this.map.once('load', () => setTimeout(restoreBasemap, PERMALINK_CONFIG.LAYER_ACTIVATION_DELAY));
+      }
+    }
+
     // If both start and end points are loaded, mark for route calculation
     // Route will be calculated after map is loaded and routing sources exist
     if (routeState.startPoint && routeState.endPoint) {
@@ -749,6 +781,9 @@ export class Permalink {
     if (toggleMissingStreets && toggleMissingStreets.checked) {
       paramParts.push('missingStreets=1');
     }
+
+    const shareBasemap = this.getCurrentBasemap();
+    if (shareBasemap !== 'standard') paramParts.push(`basemap=${shareBasemap}`);
 
     paramParts.push(...serializeProfileBarsParams());
     paramParts.push(...serializeProfile3DParams());

--- a/js/utils/permalink.js
+++ b/js/utils/permalink.js
@@ -17,6 +17,7 @@ import {
   defaultBikeCustomModel
 } from '../routing/customModel.js';
 import { MAPILLARY_SLIDER_VALUES, PERMALINK as PERMALINK_CONFIG } from './constants.js';
+import { serializeProfileBarsParams, applyProfileBarsParams } from '../routing/routeProfile/routeProfileBars.js';
 
 export class Permalink {
   constructor(map) {
@@ -47,6 +48,9 @@ export class Permalink {
     // For now, we'll update on specific events
     this.setupRouteStateListeners();
     this.setupContextLayerListeners();
+
+    // Route profile bars settings changed → reflect into the shareable URL.
+    document.addEventListener('profilebars:change', () => this.updateURL());
   }
 
   setupRouteStateListeners() {
@@ -201,14 +205,21 @@ export class Permalink {
     if (toggleMissingStreets && toggleMissingStreets.checked) {
       paramParts.push('missingStreets=1');
     }
-    
+
+    // Route profile bars settings
+    paramParts.push(...serializeProfileBarsParams());
+
     const newURL = `${window.location.pathname}?${paramParts.join('&')}`;
     window.history.replaceState({}, '', newURL);
   }
 
   async loadFromURL() {
     const params = new URLSearchParams(window.location.search);
-    
+
+    // Route profile bars settings — set options now so setupRouteProfileBars (on
+    // map load) reflects them in the UI and renders once the route is available.
+    applyProfileBarsParams(params);
+
     // Load map state
     const mapParam = params.get('map');
     if (mapParam) {
@@ -734,7 +745,9 @@ export class Permalink {
     if (toggleMissingStreets && toggleMissingStreets.checked) {
       paramParts.push('missingStreets=1');
     }
-    
+
+    paramParts.push(...serializeProfileBarsParams());
+
     return `${window.location.origin}${window.location.pathname}?${paramParts.join('&')}`;
   }
 }

--- a/readme.MD
+++ b/readme.MD
@@ -99,9 +99,35 @@ missing_mapillary_gh-routing/
 
 ## Verwendung
 
-Die Anwendung kann direkt im Browser geöffnet werden: [https://vizsim.github.io/missing_mapillary_gh-routing/](https://vizsim.github.io/missing_mapillary_gh-routing/)
+Die gehostete Version läuft hier: [https://vizsim.github.io/missing_mapillary_gh-routing/](https://vizsim.github.io/missing_mapillary_gh-routing/)
 
-Die Anwendung nutzt eine eigene GraphHopper-Instanz, die auf [ghroute.vizsim.de](https://ghroute.vizsim.de) erreichbar ist.
+Die Anwendung nutzt eine eigene GraphHopper-Instanz, die auf [ghroute.vizsim.de](https://ghroute.vizsim.de) erreichbar ist. Für die lokale Entwicklung muss kein eigenes Backend gestartet werden.
+
+### Lokal starten
+
+Die App ist eine statische Seite aus Vanilla JS mit ES-Modulen – **kein Build-Schritt, keine Installation**. Sie muss aber über einen HTTP-Server ausgeliefert werden, da ES-Module und `fetch` nicht über `file://` funktionieren (ein direkter Doppelklick auf `index.html` reicht also nicht).
+
+Am einfachsten mit [Bun](https://bun.sh) – `bunx` lädt den Server bei Bedarf und führt ihn aus, ohne dauerhaft etwas zu installieren. Im Projektordner:
+
+```bash
+bunx serve
+```
+
+Anschließend im Browser öffnen: <http://localhost:3000>
+
+Eigener Port:
+
+```bash
+bunx serve -l 8000   # -> http://localhost:8000
+```
+
+Alternativen (falls Bun nicht vorhanden ist):
+
+```bash
+python3 -m http.server 8000   # -> http://localhost:8000
+# oder
+npx serve
+```
 
 ---
 

--- a/style.css
+++ b/style.css
@@ -2160,6 +2160,106 @@ input[type="range"].slider::-moz-range-thumb,
   margin: 2px 0;
 }
 
+/* Route profile bars (on-map perpendicular histogram) */
+.profile-bars-container {
+  margin-top: 12px;
+  padding: 12px;
+  background: var(--bg-secondary);
+  border-radius: 6px;
+  border: 1px solid var(--border-primary);
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.profile-bars-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.profile-bars-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.profile-bars-controls {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.profile-bars-control-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.profile-bars-control-row label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  flex: 0 0 auto;
+}
+
+.profile-bars-control-row .heightgraph-select,
+.profile-bars-control-row .slider {
+  flex: 1 1 auto;
+  max-width: 62%;
+}
+
+.profile-bars-legend {
+  margin-top: 4px;
+}
+
+.profile-bars-legend-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.profile-bars-legend-label {
+  font-weight: 600;
+}
+
+.profile-bars-legend-gradient {
+  height: 10px;
+  border-radius: 3px;
+  margin: 4px 0;
+  border: 1px solid var(--border-secondary);
+}
+
+.profile-bars-legend-scale {
+  font-variant-numeric: tabular-nums;
+}
+
+.profile-bars-legend-empty {
+  font-size: 11px;
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
+/* Draggable cursor handle that scrubs along the barchart baseline */
+.profile-bars-handle {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 3px solid #ef4444;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  cursor: grab;
+  box-sizing: border-box;
+}
+
+.profile-bars-handle:active {
+  cursor: grabbing;
+}
+
 .heightgraph-stat-label {
   color: var(--text-tertiary);
   font-weight: 500;


### PR DESCRIPTION
> 🤖 **Written by Claude — not by @tordans.** Both the code and this description were produced by Claude (Anthropic's Claude Code), driven by @tordans. An exploratory **proof of concept**, opened as a **draft** — please review accordingly; it is not production-ready.

Two opt-in ways to visualize a numeric value along a GraphHopper route — both driven by **this repo's own route data** (elevation, derived slope, missing-Mapillary coverage), **no new data sources**. Inspired by [VisQuill's UK‑A1 viz](https://visquill.com/gallery/uk-a1).

## 1 · 2D perpendicular bars — "Routenprofil-Balken"
- Per route segment, a bar is drawn perpendicular to a **smoothed, non‑self‑intersecting baseline** derived from the route (the route is the curved X‑axis). Bar **length + color** encode the value; configurable color scales (Gefahr / sequenziell / Viridis / …).
- Bars sit ~40 px off the route on the **east / screen‑right** side by default. The baseline uses endpoint‑preserving Laplacian smoothing and is straightened until it can't fold at sharp bends; bars are spaced along the baseline so a straighter line never crowds them.
- **Shared cursor:** a draggable handle on the chart stays in sync with the height‑profile indicator and the red point on the route line.

## 2 · 3D columns — "3D-Routenprofil"
- The value as native MapLibre **`fill-extrusion` columns** (height in meters), camera tilted into a 3D view. Two variants:
  - **Auf der Route** — columns on the route itself.
  - **Auf Basislinie (Route daneben)** — columns on a smoothed baseline beside the route.
- Optional **3D buildings** (fill‑extrusion over the basemap's OpenMapTiles `building` source‑layer) and **3D terrain + atmospheric sky** (Mapterhorn DEM via `setTerrain`/`setSky`) — per the [gradients2osm](https://github.com/vizsim/gradients2osm) reference.

## Shareable state
Both features persist in the URL (`pbars…` for 2D, `p3d…` for 3D): read on first render, updated on change, only non‑defaults written. A single link restores the map view, route, 2D bars **and** 3D columns together.

## Architecture (built for the planned React port)
Self‑contained modules `js/routing/routeProfile/` (2D) and `js/routing/routeProfile3D/` (3D): pure geometry / color / value logic with a thin MapLibre+DOM layer each, plus a small shared `routeCursor.js`. Values + color scales are shared between 2D and 3D. Also: `readme.MD` gains a **"Lokal starten"** (`bunx serve`) section.

## Screenshots
_Captured during local verification — drag the images from the session under each caption._

**2D · smooth baseline — bars stay clean where the route wiggles**
<!-- ⬇️ drag screenshot here -->

**2D · shared cursor — route line ↔ chart handle ↔ height‑profile indicator**
<!-- ⬇️ drag screenshot here -->

**3D · columns on the route + extruded buildings**
<!-- ⬇️ drag screenshot here -->

**3D · columns on a baseline beside the route (Viridis) + terrain/sky**
<!-- ⬇️ drag screenshot here -->

## Notes / caveats
- Verified manually in the browser: route calculation, all values + color scales, cursor sync, the URL round‑trip for both features, and the 3D columns / buildings / terrain. No automated tests added.
- The 2D height‑profile cursor is now **persistent** (it no longer clears when the mouse leaves the chart) so the shared handle has a stable position.
- 3D terrain relief is subtle on flat routes; a hilly route shows it clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
